### PR TITLE
Replace validation asserts with typed errors and validate blob inputs

### DIFF
--- a/blobmodel/blob_shape.py
+++ b/blobmodel/blob_shape.py
@@ -85,18 +85,29 @@ def _get_double_exponential_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
     kwargs
         Additional keyword arguments.
         lam : float
-            Asymmetry parameter controlling the shape.
+            Asymmetry parameter controlling the shape, in the interval [0, 1].
+            The limits are the one-sided shapes: lam = 0 is a pure decay
+            (nonzero only for theta >= 0), lam = 1 a pure rise (nonzero only
+            for theta < 0).
 
     Returns
     -------
     np.ndarray
         Array representing the double-exponential pulse shape.
+
+    Raises
+    ------
+    ValueError
+        If lam lies outside the interval [0, 1].
     """
     lam = kwargs["lam"]
-    assert (lam > 0.0) & (lam < 1.0)
+    if not 0.0 <= lam <= 1.0:
+        raise ValueError(f"lam must be in the interval [0, 1], got lam = {lam}.")
     kern = np.zeros(shape=np.shape(theta))
-    kern[theta < 0] = np.exp(theta[theta < 0] / lam)
-    kern[theta >= 0] = np.exp(-theta[theta >= 0] / (1 - lam))
+    if lam > 0.0:
+        kern[theta < 0] = np.exp(theta[theta < 0] / lam)
+    if lam < 1.0:
+        kern[theta >= 0] = np.exp(-theta[theta >= 0] / (1 - lam))
     return kern
 
 

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -1,6 +1,5 @@
 """This module defines a Blob class and related functions for discretizing and manipulating blobs."""
 
-import warnings
 from typing import Union, Any, Optional
 from nptyping import NDArray
 import numpy as np
@@ -88,10 +87,26 @@ class Blob:
             is ignored. If None (the default), the angle is determined by
             ``blob_alignment``: the velocity phase when it is True, or 0 when False.
 
-        """
-        assert isinstance(blob_shape, AbstractBlobShape)
+        Raises
+        ------
+        TypeError
+            If ``blob_shape`` is not an ``AbstractBlobShape`` instance.
+        ValueError
+            If ``width_p`` or ``width_s`` is not positive, or if ``t_drain``
+            is not positive (every element, when it is an array).
 
-        self.int = int
+        """
+        if not isinstance(blob_shape, AbstractBlobShape):
+            raise TypeError(
+                f"blob_shape must be an AbstractBlobShape, got {type(blob_shape).__name__}."
+            )
+        if width_p <= 0 or width_s <= 0:
+            raise ValueError(
+                f"Blob widths must be positive, got width_p = {width_p} and width_s = {width_s}."
+            )
+        if np.any(np.asarray(t_drain) <= 0):
+            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
+
         self.blob_id = blob_id
         self.blob_shape = blob_shape
         self.amplitude = amplitude
@@ -154,21 +169,21 @@ class Blob:
         discretized_blob : NDArray
             Discretized blob on a 3D array with dimensions (x, y, t).
 
-        """
-        # If one_dimensional, then Ly should be 0.
-        assert (one_dimensional and Ly == 0) or not one_dimensional
+        Raises
+        ------
+        ValueError
+            If ``one_dimensional`` is True and ``Ly`` is not 0.
 
-        if (self.width_s > Ly / 3 or self.width_p > Ly / 3) and periodic_y:
-            warnings.warn(
-                "blob width big compared to Ly, mirrored blobs might become apparent."
-            )
+        """
+        if one_dimensional and Ly != 0:
+            raise ValueError(f"One dimensional blobs require Ly == 0, got Ly = {Ly}.")
 
         if not periodic_y or one_dimensional:
             return self._single_blob(
                 x, y, t, Ly, periodic_y, one_dimensional=one_dimensional
             )
 
-        time = t if type(t) in [int, float] else t[0][0]
+        time = t if np.ndim(t) == 0 else t[0][0]
         vertical_prop = self.v_y * (time - self.t_init) + self.pos_y0
         number_of_y_propagations = vertical_prop // Ly
 

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -101,8 +101,12 @@ class Model:
 
         Raises
         ------
-        AssertionError
-            If t_drain is not a single value or an array-like of length Nx.
+        TypeError
+            If blob_shape is not an AbstractBlobShape instance or blob_factory
+            is not a BlobFactory instance.
+        ValueError
+            If t_drain is neither a single value nor an array-like of length Nx,
+            or if t_drain is not positive.
 
         Warns
         -----
@@ -116,8 +120,20 @@ class Model:
             blob_shape = BlobShapeImpl()
         if blob_factory is None:
             blob_factory = DefaultBlobFactory()
-        assert isinstance(blob_shape, AbstractBlobShape)
-        assert isinstance(blob_factory, BlobFactory)
+        if not isinstance(blob_shape, AbstractBlobShape):
+            raise TypeError(
+                f"blob_shape must be an AbstractBlobShape, got {type(blob_shape).__name__}."
+            )
+        if not isinstance(blob_factory, BlobFactory):
+            raise TypeError(
+                f"blob_factory must be a BlobFactory, got {type(blob_factory).__name__}."
+            )
+        if not isinstance(t_drain, (int, float)) and len(t_drain) != Nx:
+            raise ValueError(
+                f"t_drain must be a scalar or of length Nx = {Nx}, got length {len(t_drain)}."
+            )
+        if np.any(np.asarray(t_drain) <= 0):
+            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
         if seed is not None:
             blob_factory.set_rng(np.random.default_rng(seed))
         self._one_dimensional = one_dimensional
@@ -146,10 +162,6 @@ class Model:
         self.blob_shape = blob_shape
         self.num_blobs: int = num_blobs
         self.t_drain: Union[float, NDArray] = t_drain
-
-        assert (
-            isinstance(t_drain, (int, float)) or len(t_drain) == Nx
-        ), "t_drain must be of either length 1 or Nx"
 
         self._blobs: List[Blob] = []
         self._blob_factory = blob_factory
@@ -219,6 +231,13 @@ class Model:
             the model is one-dimensional, the vertical coordinate `y` will be of length 1.
 
 
+        Warns
+        -----
+        UserWarning
+            If periodic_y is set and a sampled blob width is large compared to
+            the domain size Ly, in which case the mirror blobs used to
+            implement the periodicity may become apparent.
+
         Notes
         -----
         - speed_up is only a good approximation for blob_shape="exp"
@@ -234,6 +253,14 @@ class Model:
             blob_shape=self.blob_shape,
             t_drain=self.t_drain,
         )
+
+        if self._geometry.periodic_y and not self._one_dimensional and self._blobs:
+            max_width = max(max(blob.width_p, blob.width_s) for blob in self._blobs)
+            if max_width > self._geometry.Ly / 3:
+                warnings.warn(
+                    f"Blob width up to {max_width:.3g} is big compared to "
+                    f"Ly = {self._geometry.Ly:.3g}, mirrored blobs might become apparent."
+                )
 
         iterable = (
             tqdm(self._blobs, desc="Summing up Blobs") if self._verbose else self._blobs

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -142,18 +142,26 @@ class DefaultBlobFactory(BlobFactory):
 
         Raises
         ------
+        TypeError
+            If a distribution argument is not a DistributionEnum member.
         ValueError
             If a width distribution (`wp_dist` or `ws_dist`) is uniform with
             `free_parameter` > 2, which would produce negative blob widths.
 
         """
-        assert isinstance(A_dist, DistributionEnum)
-        assert isinstance(wp_dist, DistributionEnum)
-        assert isinstance(ws_dist, DistributionEnum)
-        assert isinstance(vx_dist, DistributionEnum)
-        assert isinstance(vy_dist, DistributionEnum)
-        assert isinstance(spp_dist, DistributionEnum)
-        assert isinstance(sps_dist, DistributionEnum)
+        for name, dist in (
+            ("A_dist", A_dist),
+            ("wp_dist", wp_dist),
+            ("ws_dist", ws_dist),
+            ("vx_dist", vx_dist),
+            ("vy_dist", vy_dist),
+            ("spp_dist", spp_dist),
+            ("sps_dist", sps_dist),
+        ):
+            if not isinstance(dist, DistributionEnum):
+                raise TypeError(
+                    f"{name} must be a DistributionEnum, got {type(dist).__name__}."
+                )
 
         for name, dist, parameter in (
             ("wp", wp_dist, wp_parameter),
@@ -218,8 +226,16 @@ class DefaultBlobFactory(BlobFactory):
         -------
         List[Blob]
             List of Blob objects generated for the Model.
+
+        Raises
+        ------
+        TypeError
+            If blob_shape is not an AbstractBlobShape instance.
         """
-        assert isinstance(blob_shape, AbstractBlobShape)
+        if not isinstance(blob_shape, AbstractBlobShape):
+            raise TypeError(
+                f"blob_shape must be an AbstractBlobShape, got {type(blob_shape).__name__}."
+            )
 
         amps = self._draw_random_variables(
             self.amplitude_dist,

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,212 @@
+"""Tests for input validation: Blob, Model, BlobFactory and pulse shape
+arguments raise typed errors instead of asserts (feedback items 6, 7, 8, 10)."""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from blobmodel import (
+    Blob,
+    BlobShapeEnum,
+    BlobShapeImpl,
+    DefaultBlobFactory,
+    DistributionEnum,
+    Model,
+)
+
+
+def make_blob(**kwargs):
+    """Return a valid Blob, with any parameter overridable through kwargs."""
+    parameters = dict(
+        blob_id=0,
+        blob_shape=BlobShapeImpl(),
+        amplitude=1,
+        width_p=1,
+        width_s=1,
+        v_x=1,
+        v_y=1,
+        pos_x0=0,
+        pos_y0=0,
+        t_init=0,
+        t_drain=10,
+    )
+    parameters.update(kwargs)
+    return Blob(**parameters)
+
+
+def test_blob_rejects_nonpositive_widths():
+    """
+    Blob widths must be positive; zero or negative values raise ValueError.
+    """
+    for bad_widths in [
+        {"width_p": 0},
+        {"width_p": -1},
+        {"width_s": 0},
+        {"width_s": -0.5},
+    ]:
+        with pytest.raises(ValueError, match="width"):
+            make_blob(**bad_widths)
+
+
+def test_blob_rejects_nonpositive_t_drain():
+    """
+    t_drain is a drain time scale and must be positive, both as a scalar and
+    element-wise as an array.
+    """
+    for bad_t_drain in [0, -1, np.array([1.0, -1.0])]:
+        with pytest.raises(ValueError, match="t_drain"):
+            make_blob(t_drain=bad_t_drain)
+
+
+def test_blob_accepts_positive_t_drain():
+    """
+    Positive scalars (including inf) and all-positive arrays are valid t_drain
+    values.
+    """
+    make_blob(t_drain=np.inf)
+    make_blob(t_drain=np.array([1.0, 2.0]))
+
+
+def test_blob_rejects_wrong_blob_shape_type():
+    """
+    blob_shape must be an AbstractBlobShape instance.
+    """
+    with pytest.raises(TypeError, match="blob_shape"):
+        make_blob(blob_shape="gauss")
+
+
+def test_discretize_blob_one_dimensional_requires_ly_zero():
+    """
+    Calling discretize_blob with one_dimensional=True and Ly != 0 raises
+    ValueError instead of an assert.
+    """
+    blob = make_blob()
+    x = np.arange(0, 10, 0.1)
+    y = np.array([0.0])
+    mesh_x, mesh_y = np.meshgrid(x, y)
+    with pytest.raises(ValueError, match="Ly"):
+        blob.discretize_blob(x=mesh_x, y=mesh_y, t=0, Ly=10, one_dimensional=True)
+
+
+def test_discretize_blob_accepts_numpy_scalar_time():
+    """
+    discretize_blob with periodic_y accepts numpy scalar times, which the old
+    `type(t) in [int, float]` check misclassified as arrays.
+    """
+    blob = make_blob(v_y=5)
+    x = np.arange(0, 10, 0.1)
+    y = np.array([0, 1])
+    mesh_x, mesh_y = np.meshgrid(x, y)
+
+    reference = blob.discretize_blob(x=mesh_x, y=mesh_y, t=1.0, periodic_y=True, Ly=10)
+    values = blob.discretize_blob(
+        x=mesh_x, y=mesh_y, t=np.float64(1.0), periodic_y=True, Ly=10
+    )
+    np.testing.assert_array_equal(values, reference)
+
+
+def test_double_exp_lam_outside_unit_interval_raises():
+    """
+    The double-exponential asymmetry parameter lam must lie in [0, 1].
+    """
+    ps = BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp)
+    theta = np.linspace(-5, 5, 100)
+    for bad_lam in [-0.1, 1.1]:
+        with pytest.raises(ValueError, match="lam"):
+            ps.get_blob_shape_p(theta, lam=bad_lam)
+
+
+def test_double_exp_lam_limits_are_one_sided():
+    """
+    lam = 0 and lam = 1 are valid one-sided limits of the double-exponential
+    shape: a pure decay and a pure rise, respectively.
+    """
+    ps = BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp)
+    theta = np.linspace(-5, 5, 100)
+
+    pure_decay = ps.get_blob_shape_p(theta, lam=0)
+    expected_decay = np.zeros_like(theta)
+    expected_decay[theta >= 0] = np.exp(-theta[theta >= 0])
+    np.testing.assert_allclose(pure_decay, expected_decay)
+
+    pure_rise = ps.get_blob_shape_p(theta, lam=1)
+    expected_rise = np.zeros_like(theta)
+    expected_rise[theta < 0] = np.exp(theta[theta < 0])
+    np.testing.assert_allclose(pure_rise, expected_rise)
+
+
+def test_model_rejects_wrong_types():
+    """
+    Model raises TypeError for blob_shape/blob_factory of the wrong type.
+    """
+    with pytest.raises(TypeError, match="blob_shape"):
+        Model(blob_shape="gauss")
+    with pytest.raises(TypeError, match="blob_factory"):
+        Model(blob_factory="default")
+
+
+def test_model_rejects_bad_t_drain():
+    """
+    Model raises ValueError for t_drain arrays of the wrong length and for
+    non-positive t_drain values.
+    """
+    with pytest.raises(ValueError, match="t_drain"):
+        Model(Nx=5, t_drain=np.ones(3))
+    with pytest.raises(ValueError, match="t_drain"):
+        Model(t_drain=-1)
+    with pytest.raises(ValueError, match="t_drain"):
+        Model(Nx=2, t_drain=np.array([1.0, 0.0]))
+
+
+def test_periodic_y_width_warning_fired_once_with_values():
+    """
+    The blob-width warning for periodic_y is emitted once per realization from
+    Model (not once per blob) and reports the offending width and Ly.
+    """
+    model = Model(
+        Nx=5,
+        Ny=5,
+        Lx=5,
+        Ly=1,
+        dt=1,
+        T=2,
+        periodic_y=True,
+        num_blobs=10,
+        verbose=False,
+        seed=42,
+    )
+    with pytest.warns(UserWarning, match="mirrored blobs") as record:
+        model.make_realization()
+
+    width_warnings = [w for w in record if "mirrored blobs" in str(w.message)]
+    assert len(width_warnings) == 1
+    assert "Ly = 1" in str(width_warnings[0].message)
+
+
+def test_periodic_y_no_width_warning_for_small_widths():
+    """
+    No width warning is emitted when the blob widths are small compared to Ly.
+    """
+    model = Model(
+        Nx=5,
+        Ny=5,
+        Lx=5,
+        Ly=10,
+        dt=1,
+        T=2,
+        periodic_y=True,
+        num_blobs=10,
+        verbose=False,
+        seed=42,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model.make_realization()
+
+
+def test_blob_junk_attribute_removed():
+    """
+    Blob no longer stores the int builtin as an attribute.
+    """
+    assert not hasattr(make_blob(), "int")

--- a/tests/test_stochasticality.py
+++ b/tests/test_stochasticality.py
@@ -35,11 +35,10 @@ def test_mean_of_distribution():
 
 def test_not_implemented_distribution():
     """
-    Checks that a KeyError is thrown when using unknown strings as distributions.
+    Checks that a TypeError is thrown when using unknown strings as distributions.
     """
-    with pytest.raises(AssertionError):
-        bf = DefaultBlobFactory(A_dist="something_different")
-        bf.sample_blobs(1, 1, 1, BlobShapeImpl(), 1)
+    with pytest.raises(TypeError, match="A_dist"):
+        DefaultBlobFactory(A_dist="something_different")
 
 
 def test_uniform_width_parameter_too_big_raises():


### PR DESCRIPTION
- Blob rejects non-positive widths and non-positive t_drain (scalar or element-wise) with ValueError; blob_shape type errors raise TypeError.
- discretize_blob raises ValueError (not assert) when one_dimensional and Ly != 0, and accepts numpy scalar times (np.ndim check instead of type(t) in [int, float]).
- double-exp lam domain decided as closed [0, 1]: the one-sided limits lam=0 (pure decay) and lam=1 (pure rise) are valid; outside raises ValueError.
- Model validates blob_shape/blob_factory types and t_drain length and positivity with typed errors instead of asserts.
- DefaultBlobFactory distribution-type asserts replaced with TypeError.
- Blob-width periodicity warning moved from per-blob discretize_blob to once per Model.make_realization, now reporting the width and Ly.
- Remove junk attribute `self.int = int` in Blob.__init__.