### PR TITLE
Fix docstring drift and BlobShapeImpl method shadowing

### DIFF
--- a/blobmodel/blob_shape.py
+++ b/blobmodel/blob_shape.py
@@ -182,43 +182,73 @@ def _get_dipole_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
 
 
 class BlobShapeImpl(AbstractBlobShape):
-    """Implementation of the AbstractPulseShape class."""
+    """Implementation of the AbstractBlobShape class."""
 
     def __init__(
         self,
-        pulse_shape_p=BlobShapeEnum.gaussian,
-        pulse_shape_s=BlobShapeEnum.gaussian,
+        pulse_shape_p: BlobShapeEnum = BlobShapeEnum.gaussian,
+        pulse_shape_s: BlobShapeEnum = BlobShapeEnum.gaussian,
     ):
         """Initialize the BlobShapeImpl object.
 
-        Attributes
+        Parameters
         ----------
-        pulse_shape_p : str, optional
-            Type of pulse shape in the principal direction, by default "gauss".
-        pulse_shape_s : str, optional
-            Type of pulse shape in the secondary direction, by default "gauss".
+        pulse_shape_p : BlobShapeEnum, optional
+            Type of pulse shape in the principal direction,
+            by default BlobShapeEnum.gaussian.
+        pulse_shape_s : BlobShapeEnum, optional
+            Type of pulse shape in the secondary direction,
+            by default BlobShapeEnum.gaussian.
+
+        Raises
+        ------
+        NotImplementedError
+            If a pulse shape is not a member of BlobShapeEnum with an
+            implemented shape function.
         """
         if (
-            pulse_shape_p not in BlobShapeImpl.__GENERATORS.keys()
-            or pulse_shape_s not in BlobShapeImpl.__GENERATORS.keys()
+            pulse_shape_p not in BlobShapeImpl.__GENERATORS
+            or pulse_shape_s not in BlobShapeImpl.__GENERATORS
         ):
             raise NotImplementedError(
                 f"{self.__class__.__name__}.blob_shape not implemented"
             )
-        self.get_blob_shape_p = BlobShapeImpl.__GENERATORS.get(pulse_shape_p)
-        self.get_blob_shape_s = BlobShapeImpl.__GENERATORS.get(pulse_shape_s)
+        self._shape_p = BlobShapeImpl.__GENERATORS[pulse_shape_p]
+        self._shape_s = BlobShapeImpl.__GENERATORS[pulse_shape_s]
 
     def get_blob_shape_p(self, theta: np.ndarray, **kwargs) -> np.ndarray:
+        """Compute the pulse shape in the principal direction.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            Array of theta values.
+        kwargs
+            Additional keyword arguments passed to the shape function.
+
+        Returns
+        -------
+        np.ndarray
+            Array representing the pulse shape in the principal direction.
         """
-        Compute the pulse shape in the principal direction.
-        """
-        raise NotImplementedError
+        return self._shape_p(theta, **kwargs)
 
     def get_blob_shape_s(self, theta: np.ndarray, **kwargs) -> np.ndarray:
+        """Compute the pulse shape in the secondary direction.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            Array of theta values.
+        kwargs
+            Additional keyword arguments passed to the shape function.
+
+        Returns
+        -------
+        np.ndarray
+            Array representing the pulse shape in the secondary direction.
         """
-        Compute the pulse shape in the secondary direction.
-        """
-        raise NotImplementedError
+        return self._shape_s(theta, **kwargs)
 
     __GENERATORS = {
         BlobShapeEnum.exp: _get_exponential_shape,

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -147,11 +147,14 @@ class Blob:
         Parameters
         ----------
         x : NDArray
-            Grid coordinates in the x-direction.
+            Grid coordinates in the x-direction, as a meshgrid array of shape
+            (Ny, Nx, Nt).
         y : NDArray
-            Grid coordinates in the y-direction.
+            Grid coordinates in the y-direction, as a meshgrid array of shape
+            (Ny, Nx, Nt).
         t : NDArray
-            Time coordinates.
+            Time coordinates, as a meshgrid array of shape (Ny, Nx, Nt).
+            A scalar t (single time point) is also accepted.
         Ly : float
             Length of domain in the y-direction.
         periodic_y : bool, optional
@@ -167,7 +170,8 @@ class Blob:
         Returns
         -------
         discretized_blob : NDArray
-            Discretized blob on a 3D array with dimensions (x, y, t).
+            Discretized blob on a 3D array with dimensions (y, x, t),
+            i.e. shape (Ny, Nx, Nt).
 
         Raises
         ------

--- a/blobmodel/geometry.py
+++ b/blobmodel/geometry.py
@@ -39,9 +39,11 @@ class Geometry:
         dt : float
             Time step.
         T : float
-            Time length.
+            End time of the simulation. The time grid is
+            ``np.arange(t_init, T, dt)``, so the realized time length is
+            ``T - t_init``.
         t_init : float
-            Initial time
+            Initial time.
         periodic_y : bool
             Flag indicating whether periodicity is allowed in the y-direction.
         """

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -57,7 +57,9 @@ class Model:
         dt : float, optional
             Time step.
         T : float, optional
-            Time length.
+            End time of the simulation. The time grid is
+            ``np.arange(t_init, T, dt)``, so the realized time length is
+            ``T - t_init``.
         periodic_y : bool, optional
             Allow periodicity in the y-direction.
             Important: only good approximation for Ly >> blob width
@@ -67,8 +69,8 @@ class Model:
         num_blobs : int, optional
             Number of blobs.
         t_drain : float or array-like, optional
-            Drain time for the blobs. Can be a single float value or an array-like
-            of length Nx.
+            Drain time scale of the blobs (exponential decay). Can be a single
+            float value or an array-like of length Nx.
         blob_factory : BlobFactory, optional
             BlobFactory instance for setting blob parameter distributions.
             By default None, in which case a `DefaultBlobFactory` is created.
@@ -227,7 +229,8 @@ class Model:
             - x: Horizontal coordinate
             - y: Vertical coordinate
             - t: Time coordinate
-            The resulting blob density, evaluated in the grid, is given by the `DataArray`, `n`. In case that
+            The resulting blob density, evaluated in the grid, is given by the `DataArray`, `n`, with
+            dimension order (y, x, t), i.e. shape (Ny, Nx, Nt). In case that
             the model is one-dimensional, the vertical coordinate `y` will be of length 1.
 
 

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -214,13 +214,15 @@ class DefaultBlobFactory(BlobFactory):
         Ly : float
             Size of the domain in the y-direction.
         T : float
-            Total time duration.
+            End time of the simulation. Blob arrival times are sampled
+            uniformly in [0, T).
         num_blobs : int
             Number of blobs to generate.
         blob_shape : AbstractBlobShape
             Object representing the shape of the blobs.
-        t_drain : float
-            Time at which the blobs start draining.
+        t_drain : float or NDArray
+            Drain time scale of the blobs (exponential decay). Either a
+            scalar or an array of length Nx.
 
         Returns
         -------


### PR DESCRIPTION
Docstring fixes (feedback item 9):
- BlobShapeImpl: document BlobShapeEnum parameters (string shape names were removed in 1.2) under a proper Parameters header, and fix the AbstractPulseShape -> AbstractBlobShape class reference.
- discretize_blob: the returned array has dimensions (y, x, t), i.e. shape (Ny, Nx, Nt), not (x, y, t); document that x/y/t are meshgrid arrays and that a scalar t is accepted. Model.make_realization now states the (y, x, t) order of the density DataArray n.
- Geometry/Model: T is the absolute end time (time grid is np.arange(t_init, T, dt)), not a duration.
- sample_blobs/Model: t_drain is a drain time scale (exponential decay), scalar or length-Nx array — not a drain start time; T bounds the uniformly sampled blob arrival times.

Refactor (feedback item 11): BlobShapeImpl no longer assigns get_blob_shape_p/_s as instance attributes shadowing unreachable NotImplementedError placeholder methods. The shape generator functions are stored in private attributes and dispatched from real, documented, mypy-checkable methods. No behavior change.