### PR TITLE
Stop tests leaving .nc artifacts; drop wildcard import and dead ABC

### DIFF
--- a/blobmodel/distributions.py
+++ b/blobmodel/distributions.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from abc import ABC, abstractmethod
 import numpy as np
 
 
@@ -13,18 +12,6 @@ class DistributionEnum(Enum):
     normal = 5
     uniform = 6
     rayleigh = 7
-
-
-class AbstractDistribution(ABC):
-    """Abstract class used to represent and implement a distribution function."""
-
-    @abstractmethod
-    def sample(
-        self,
-        num_blobs: int,
-        **kwargs,
-    ) -> np.ndarray:
-        raise NotImplementedError
 
 
 def _sample_deg(num_blobs, rng, **kwargs):

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -1,10 +1,12 @@
 """This module defines a class for generating blob parameters."""
 
+from abc import ABC, abstractmethod
 from nptyping import NDArray
 from typing import List, Union, Callable
+import numpy as np
 from .blobs import Blob
 from .blob_shape import AbstractBlobShape
-from .distributions import *
+from .distributions import DISTRIBUTIONS, DistributionEnum
 
 
 class BlobFactory(ABC):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,7 +1,11 @@
 # The following tests check that the docs examples run, if they fail make sure to change the docs too!
 
 
-def test_getting_started():
+def test_getting_started(tmp_path, monkeypatch):
+    # Write example.nc into a temp directory instead of the repo root. The
+    # chdir happens outside the PLACEHOLDER markers so the docs snippet
+    # (docs/getting_started.rst) is unaffected.
+    monkeypatch.chdir(tmp_path)
     # PLACEHOLDER getting_started_0
     from blobmodel import Model
 


### PR DESCRIPTION
- test_docs.py::test_getting_started now runs in tmp_path (monkeypatch.chdir placed outside the PLACEHOLDER markers, so the docs literalinclude snippets are unchanged); the test suite no longer writes example.nc into the repo root.
- stochasticality.py imports DISTRIBUTIONS/DistributionEnum, ABC/ abstractmethod and numpy explicitly instead of relying on `from .distributions import *`.
- Deleted the never-subclassed, never-referenced AbstractDistribution from distributions.py (DISTRIBUTIONS maps enums to plain functions).