### PR TITLE
Add BlobListFactory, CallableBlobFactory and Model.from_blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ You can specify the blob parameters with a BlobFactory class. The DefaultBlobFac
 from blobmodel import DefaultBlobFactory, DistributionEnum, Geometry, Model
 
 # use DefaultBlobFactory to define distribution functions of random variables
-my_blob_factory = DefaultBlobFactory(A_dist=DistributionEnum.normal, A_parameter=5)
+my_blob_factory = DefaultBlobFactory(
+    A_dist=DistributionEnum.normal, A_parameter=5, t_drain=100
+)
 
 # pass on my_blob_factory when creating the Model
 bm = Model(
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=20),
         blob_factory=my_blob_factory,
-        t_drain=100,
         num_blobs=100,
     )
 ```

--- a/blobmodel/__init__.py
+++ b/blobmodel/__init__.py
@@ -1,7 +1,12 @@
 from .model import Model
 from .blobs import Blob
 from .plotting import show_model
-from .stochasticality import BlobFactory, DefaultBlobFactory
+from .stochasticality import (
+    BlobFactory,
+    BlobListFactory,
+    CallableBlobFactory,
+    DefaultBlobFactory,
+)
 from .geometry import Geometry
 from .blob_shape import AbstractBlobShape, BlobShapeImpl, BlobShapeEnum
 from .distributions import DistributionEnum

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -72,7 +72,7 @@ class Blob:
         t_init : float
             Initial time of the blob.
         t_drain : Union[float, NDArray]
-            Time scale for the blob to drain.
+            Time scale for the blob to drain. Use ``np.inf`` for no draining.
         shape_parameters_p : dict
             Additional shape parameters for the propagation direction.
         shape_parameters_s : dict

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -5,7 +5,7 @@ import xarray as xr
 from tqdm import tqdm
 from typing import List, Union
 from .blobs import Blob
-from .stochasticality import BlobFactory, DefaultBlobFactory
+from .stochasticality import BlobFactory, BlobListFactory, DefaultBlobFactory
 from .geometry import Geometry
 from nptyping import NDArray
 import warnings
@@ -52,7 +52,8 @@ class Model:
             Number of blobs.
         t_drain : float or array-like, optional
             Drain time scale of the blobs (exponential decay). Can be a single
-            float value or an array-like of length Nx.
+            float value or an array-like of length Nx. Use `np.inf` for no
+            draining.
         blob_factory : BlobFactory, optional
             BlobFactory instance for setting blob parameter distributions.
             By default None, in which case a `DefaultBlobFactory` is created.
@@ -81,6 +82,13 @@ class Model:
             constructed with; custom factories only honor it if they draw from
             `self.rng`. By default None, i.e. the factory's own generator is
             kept (non-reproducible unless the factory was seeded).
+
+        Notes
+        -----
+        - `num_blobs`, `blob_shape` and `t_drain` are only forwarded to the
+          blob factory's `sample_blobs`; a custom factory may ignore any of
+          them (`BlobListFactory` ignores all three). For pre-built blob
+          lists prefer `Model.from_blobs`, which hides these parameters.
 
         Raises
         ------
@@ -161,6 +169,56 @@ class Model:
         return (
             f"2d Blob Model with"
             + f" num_blobs:{self.num_blobs} and t_drain:{self.t_drain}"
+        )
+
+    @classmethod
+    def from_blobs(
+        cls,
+        blobs: List[Blob],
+        geometry: Union[Geometry, None] = None,
+        labels: str = "off",
+        label_border: float = 0.75,
+        one_dimensional: bool = False,
+        verbose: bool = True,
+    ) -> "Model":
+        """
+        Create a Model that realizes a pre-built list of blobs.
+
+        Shortcut for the hand-built-blobs workflow: wraps `blobs` in a
+        `BlobListFactory`, so the sampling parameters of `Model.__init__`
+        (`num_blobs`, `blob_shape`, `t_drain`) need not be supplied — each
+        `Blob` already carries its own parameters.
+
+        Parameters
+        ----------
+        blobs : List[Blob]
+            Blobs to sum in `make_realization`.
+        geometry : Geometry, optional
+            Grid on which the blobs are discretized, as in `Model.__init__`.
+        labels : str, optional
+            Blob label setting, as in `Model.__init__`.
+        label_border : float, optional
+            Defines region of blob, as in `Model.__init__`.
+        one_dimensional : bool, optional
+            If True, the perpendicular shape of the blobs is discarded, as in
+            `Model.__init__`.
+        verbose : bool, optional
+            If True, print a loading bar.
+
+        Returns
+        -------
+        Model
+            Model whose realizations sum exactly the given blobs.
+        """
+        return cls(
+            geometry=geometry,
+            num_blobs=len(blobs),
+            t_drain=np.inf,
+            blob_factory=BlobListFactory(blobs),
+            labels=labels,
+            label_border=label_border,
+            one_dimensional=one_dimensional,
+            verbose=verbose,
         )
 
     @property

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -7,7 +7,6 @@ from typing import List, Union
 from .blobs import Blob
 from .stochasticality import BlobFactory, BlobListFactory, DefaultBlobFactory
 from .geometry import Geometry
-from nptyping import NDArray
 import warnings
 from .blob_shape import AbstractBlobShape, BlobShapeImpl
 
@@ -26,7 +25,6 @@ class Model:
         geometry: Union[Geometry, None] = None,
         blob_shape: Union[AbstractBlobShape, None] = None,
         num_blobs: int = 1000,
-        t_drain: Union[float, NDArray, int] = 10,
         blob_factory: Union[BlobFactory, None] = None,
         labels: str = "off",
         label_border: float = 0.75,
@@ -50,13 +48,11 @@ class Model:
             By default None, in which case a gaussian `BlobShapeImpl` is created.
         num_blobs : int, optional
             Number of blobs.
-        t_drain : float or array-like, optional
-            Drain time scale of the blobs (exponential decay). Can be a single
-            float value or an array-like of length Nx. Use `np.inf` for no
-            draining.
         blob_factory : BlobFactory, optional
             BlobFactory instance for setting blob parameter distributions.
-            By default None, in which case a `DefaultBlobFactory` is created.
+            By default None, in which case a `DefaultBlobFactory` is created
+            (whose default is non-draining blobs, `t_drain=np.inf` — blob
+            draining is owned by the factory, not the model).
         labels : str, optional
             Blob label setting. Possible values: "off", "same", "individual".
             "off": no blob labels returned
@@ -85,10 +81,10 @@ class Model:
 
         Notes
         -----
-        - `num_blobs`, `blob_shape` and `t_drain` are only forwarded to the
-          blob factory's `sample_blobs`; a custom factory may ignore any of
-          them (`BlobListFactory` ignores all three). For pre-built blob
-          lists prefer `Model.from_blobs`, which hides these parameters.
+        - `num_blobs` and `blob_shape` are only forwarded to the blob
+          factory's `sample_blobs`; a custom factory may ignore either of
+          them (`BlobListFactory` ignores both). For pre-built blob lists
+          prefer `Model.from_blobs`, which hides these parameters.
 
         Raises
         ------
@@ -97,9 +93,8 @@ class Model:
             AbstractBlobShape instance or blob_factory is not a BlobFactory
             instance.
         ValueError
-            If t_drain is neither a single value nor an array-like of length Nx,
-            or if t_drain is not positive, or if the model is one-dimensional
-            and the geometry does not have Ny=1 and Ly=0.
+            If the model is one-dimensional and the geometry does not have
+            Ny=1 and Ly=0.
 
         Warns
         -----
@@ -124,13 +119,6 @@ class Model:
             raise TypeError(
                 f"blob_factory must be a BlobFactory, got {type(blob_factory).__name__}."
             )
-        if not isinstance(t_drain, (int, float)) and len(t_drain) != geometry.Nx:
-            raise ValueError(
-                f"t_drain must be a scalar or of length Nx = {geometry.Nx}, "
-                f"got length {len(t_drain)}."
-            )
-        if np.any(np.asarray(t_drain) <= 0):
-            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
         if seed is not None:
             blob_factory.set_rng(np.random.default_rng(seed))
         self._one_dimensional = one_dimensional
@@ -148,7 +136,6 @@ class Model:
         self._geometry: Geometry = geometry
         self.blob_shape = blob_shape
         self.num_blobs: int = num_blobs
-        self.t_drain: Union[float, NDArray] = t_drain
 
         self._blobs: List[Blob] = []
         self._blob_factory = blob_factory
@@ -166,10 +153,7 @@ class Model:
         str
             String representation of the Model.
         """
-        return (
-            f"2d Blob Model with"
-            + f" num_blobs:{self.num_blobs} and t_drain:{self.t_drain}"
-        )
+        return f"2d Blob Model with num_blobs:{self.num_blobs}"
 
     @classmethod
     def from_blobs(
@@ -186,8 +170,8 @@ class Model:
 
         Shortcut for the hand-built-blobs workflow: wraps `blobs` in a
         `BlobListFactory`, so the sampling parameters of `Model.__init__`
-        (`num_blobs`, `blob_shape`, `t_drain`) need not be supplied — each
-        `Blob` already carries its own parameters.
+        (`num_blobs`, `blob_shape`) need not be supplied — each `Blob`
+        already carries its own parameters.
 
         Parameters
         ----------
@@ -213,7 +197,6 @@ class Model:
         return cls(
             geometry=geometry,
             num_blobs=len(blobs),
-            t_drain=np.inf,
             blob_factory=BlobListFactory(blobs),
             labels=labels,
             label_border=label_border,
@@ -274,6 +257,12 @@ class Model:
             the model is one-dimensional, the vertical coordinate `y` will be of length 1.
 
 
+        Raises
+        ------
+        ValueError
+            If a sampled blob has an array-valued t_drain whose length does
+            not match the geometry's Nx.
+
         Warns
         -----
         UserWarning
@@ -294,8 +283,20 @@ class Model:
             T=self._geometry.T,
             num_blobs=self.num_blobs,
             blob_shape=self.blob_shape,
-            t_drain=self.t_drain,
         )
+
+        # Array-valued t_drain (drain time varying along x) must match the
+        # grid; only the model knows Nx, so this cannot be checked by the
+        # factory or the blob itself.
+        for blob in self._blobs:
+            if (
+                not isinstance(blob.t_drain, (int, float))
+                and len(blob.t_drain) != self._geometry.Nx
+            ):
+                raise ValueError(
+                    f"t_drain must be a scalar or of length Nx = {self._geometry.Nx}, "
+                    f"got length {len(blob.t_drain)}."
+                )
 
         if self._geometry.periodic_y and not self._one_dimensional and self._blobs:
             max_width = max(max(blob.width_p, blob.width_s) for blob in self._blobs)

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -52,6 +52,109 @@ class BlobFactory(ABC):
         self.rng = rng
 
 
+class BlobListFactory(BlobFactory):
+    """BlobFactory that returns a pre-built list of blobs.
+
+    Use this (typically through `Model.from_blobs`) when the blobs are
+    constructed by hand instead of sampled from distributions. All
+    `sample_blobs` arguments (`num_blobs`, `blob_shape`, `t_drain`, ...) are
+    ignored: each `Blob` already carries its own parameters.
+    """
+
+    def __init__(self, blobs: List[Blob]) -> None:
+        """
+        Initialize the factory with the list of blobs to realize.
+
+        Parameters
+        ----------
+        blobs : List[Blob]
+            Blobs returned by every `sample_blobs` call.
+        """
+        self._blobs = list(blobs)
+
+    def sample_blobs(
+        self,
+        Ly: float,
+        T: float,
+        num_blobs: int,
+        blob_shape: AbstractBlobShape,
+        t_drain: Union[float, NDArray],
+    ) -> List[Blob]:
+        """Return the stored blob list. All arguments are ignored."""
+        return list(self._blobs)
+
+    def is_one_dimensional(self) -> bool:
+        """
+        Returns True if all stored blobs have zero perpendicular velocity.
+
+        Returns
+        -------
+        bool
+            True if `v_y == 0` for every blob, False otherwise.
+        """
+        return all(blob.v_y == 0 for blob in self._blobs)
+
+
+class CallableBlobFactory(BlobFactory):
+    """BlobFactory that builds each blob by calling a user-provided getter.
+
+    The getter receives the factory's random number generator, so blobs
+    sampled through this factory are reproducible via
+    `CallableBlobFactory(seed=...)` or `Model(seed=...)` — provided the getter
+    draws its random numbers from the generator it is given instead of the
+    global `np.random` state.
+    """
+
+    def __init__(
+        self,
+        blob_getter: Callable[[np.random.Generator], Blob],
+        one_dimensional: bool = False,
+        seed: Union[int, np.random.Generator, None] = None,
+    ) -> None:
+        """
+        Initialize the factory with a blob getter.
+
+        Parameters
+        ----------
+        blob_getter : Callable[[np.random.Generator], Blob]
+            Function called once per blob with the factory's random number
+            generator; must return a `Blob`.
+        one_dimensional : bool, optional
+            Whether the blobs produced by the getter are compatible with a
+            one-dimensional model (i.e. have `v_y == 0`). Cannot be inferred
+            from the getter, so it must be declared. By default False.
+        seed : int, np.random.Generator or None, optional
+            Seed (or an already constructed `numpy.random.Generator`) for the
+            generator passed to `blob_getter`. A seed passed to `Model` takes
+            precedence: it replaces this factory's generator via `set_rng`.
+            By default None, i.e. a freshly seeded generator
+            (non-reproducible).
+        """
+        self._blob_getter = blob_getter
+        self._one_dimensional = one_dimensional
+        self.rng = np.random.default_rng(seed)
+
+    def sample_blobs(
+        self,
+        Ly: float,
+        T: float,
+        num_blobs: int,
+        blob_shape: AbstractBlobShape,
+        t_drain: Union[float, NDArray],
+    ) -> List[Blob]:
+        """
+        Create `num_blobs` blobs by calling the getter with `self.rng`.
+
+        `Ly`, `T`, `blob_shape` and `t_drain` are ignored: the getter is
+        expected to fully specify each blob.
+        """
+        return [self._blob_getter(self.rng) for _ in range(num_blobs)]
+
+    def is_one_dimensional(self) -> bool:
+        """Return the `one_dimensional` flag declared at construction."""
+        return self._one_dimensional
+
+
 class DefaultBlobFactory(BlobFactory):
     """Default implementation of BlobFactory.
 

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -22,10 +22,15 @@ class BlobFactory(ABC):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: Union[float, NDArray],
     ) -> List[Blob]:
         """
         Creates a list of Blobs used in Model.
+
+        Notes
+        -----
+        - Blob draining is owned by the factory, not the `Model`: each `Blob`
+          carries its own `t_drain` (`DefaultBlobFactory` takes it as a
+          constructor argument, `np.inf` — no draining — by default).
         """
         raise NotImplementedError
 
@@ -78,7 +83,6 @@ class BlobListFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: Union[float, NDArray],
     ) -> List[Blob]:
         """Return the stored blob list. All arguments are ignored."""
         return list(self._blobs)
@@ -140,13 +144,12 @@ class CallableBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: Union[float, NDArray],
     ) -> List[Blob]:
         """
         Create `num_blobs` blobs by calling the getter with `self.rng`.
 
-        `Ly`, `T`, `blob_shape` and `t_drain` are ignored: the getter is
-        expected to fully specify each blob.
+        `Ly`, `T` and `blob_shape` are ignored: the getter is expected to
+        fully specify each blob.
         """
         return [self._blob_getter(self.rng) for _ in range(num_blobs)]
 
@@ -178,6 +181,7 @@ class DefaultBlobFactory(BlobFactory):
         vy_parameter: float = 1.0,
         shape_param_p_parameter: float = 0.5,
         shape_param_s_parameter: float = 0.5,
+        t_drain: Union[float, NDArray, int] = np.inf,
         blob_alignment: bool = False,
         seed: Union[int, np.random.Generator, None] = None,
     ) -> None:
@@ -217,6 +221,11 @@ class DefaultBlobFactory(BlobFactory):
             Free parameter for the shape parameter distribution in the principal direction, by default 0.5
         shape_param_s_parameter : float, optional
             Free parameter for the shape parameter distribution in the secondary direction, by default 0.5
+        t_drain : float or array-like, optional
+            Drain time scale of the blobs (exponential decay), applied to every
+            sampled blob. Can be a single value or an array-like of length Nx
+            (the number of grid points of the model's geometry in the
+            x-direction). By default `np.inf`, i.e. no draining.
         blob_alignment : bool, optional
             If blob_alignment == True, the blob shapes are rotated in the propagation direction of the blob.
             If blob_alignment == False, the blob shapes are independent of the propagation direction.
@@ -251,7 +260,8 @@ class DefaultBlobFactory(BlobFactory):
             If a distribution argument is not a DistributionEnum member.
         ValueError
             If a width distribution (`wp_dist` or `ws_dist`) is uniform with
-            `free_parameter` > 2, which would produce negative blob widths.
+            `free_parameter` > 2, which would produce negative blob widths,
+            or if `t_drain` is not positive.
 
         """
         for name, dist in (
@@ -291,8 +301,12 @@ class DefaultBlobFactory(BlobFactory):
         self.width_s_parameter = ws_parameter
         self.velocity_x_parameter = vx_parameter
         self.velocity_y_parameter = vy_parameter
+        if np.any(np.asarray(t_drain) <= 0):
+            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
+
         self.shape_param_p_parameter = shape_param_p_parameter
         self.shape_param_s_parameter = shape_param_s_parameter
+        self.t_drain = t_drain
         self.blob_alignment = blob_alignment
         self.theta_setter: Union[Callable[[], float], None] = None
         self.rng = np.random.default_rng(seed)
@@ -309,10 +323,12 @@ class DefaultBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: Union[float, NDArray],
     ) -> List[Blob]:
         """
         Creates a list of Blobs used in the Model.
+
+        Every blob is given the factory's `t_drain` (a constructor argument,
+        `np.inf` — no draining — by default).
 
         Parameters
         ----------
@@ -325,9 +341,6 @@ class DefaultBlobFactory(BlobFactory):
             Number of blobs to generate.
         blob_shape : AbstractBlobShape
             Object representing the shape of the blobs.
-        t_drain : float or NDArray
-            Drain time scale of the blobs (exponential decay). Either a
-            scalar or an array of length Nx.
 
         Returns
         -------
@@ -386,7 +399,7 @@ class DefaultBlobFactory(BlobFactory):
                 pos_x0=posxs[i],
                 pos_y0=posys[i],
                 t_init=t_inits[i],
-                t_drain=t_drain,
+                t_drain=self.t_drain,
                 shape_parameters_p=spxs_dict[i],
                 shape_parameters_s=spys_dict[i],
                 blob_alignment=self.blob_alignment,

--- a/docs/blob_factory.rst
+++ b/docs/blob_factory.rst
@@ -57,6 +57,36 @@ We chose the defualt distributions for all other blob parameters. We would set u
    :start-after: # PLACEHOLDER blob_factory_0
    :end-before: # PLACEHOLDER blob_factory_1
 
+++++++++++++++++++++++++++++++++++
+Pre-built blobs: Model.from_blobs
+++++++++++++++++++++++++++++++++++
+
+If you already know exactly which blobs you want to realize, you don't need parameter distributions at all:
+build the ``Blob`` objects yourself and hand the list to ``Model.from_blobs``.
+Each ``Blob`` carries its own parameters, so the sampling arguments of ``Model``
+(``num_blobs``, ``blob_shape`` and ``t_drain``) are not needed:
+
+.. literalinclude:: ../tests/test_docs.py
+   :language: python
+   :start-after: # PLACEHOLDER prebuilt_blobs_0
+   :end-before: # PLACEHOLDER prebuilt_blobs_1
+
+``Model.from_blobs`` is a shortcut for wrapping the list in a ``BlobListFactory``, which you can also use directly with ``Model(blob_factory=...)``.
+Note that ``t_drain=np.inf`` is the documented way of specifying non-draining blobs.
+
++++++++++++++++++++
+CallableBlobFactory
++++++++++++++++++++
+
+If you want custom randomness per blob without writing a whole ``BlobFactory`` subclass, use ``CallableBlobFactory``:
+it builds each blob by calling a getter function with the factory's random number generator.
+Drawing the random numbers from that generator (instead of the global ``np.random`` state) makes the realization reproducible via ``CallableBlobFactory(seed=...)`` or ``Model(seed=...)``:
+
+.. literalinclude:: ../tests/test_docs.py
+   :language: python
+   :start-after: # PLACEHOLDER callable_blob_factory_0
+   :end-before: # PLACEHOLDER callable_blob_factory_1
+
 +++++++++++++++++
 CustomBlobFactory
 +++++++++++++++++

--- a/docs/blob_factory.rst
+++ b/docs/blob_factory.rst
@@ -64,7 +64,7 @@ Pre-built blobs: Model.from_blobs
 If you already know exactly which blobs you want to realize, you don't need parameter distributions at all:
 build the ``Blob`` objects yourself and hand the list to ``Model.from_blobs``.
 Each ``Blob`` carries its own parameters, so the sampling arguments of ``Model``
-(``num_blobs``, ``blob_shape`` and ``t_drain``) are not needed:
+(``num_blobs`` and ``blob_shape``) are not needed:
 
 .. literalinclude:: ../tests/test_docs.py
    :language: python

--- a/docs/changing_t_drain_plot.py
+++ b/docs/changing_t_drain_plot.py
@@ -1,27 +1,38 @@
-from blobmodel import Geometry, Model, DefaultBlobFactory
+from blobmodel import (
+    BlobShapeEnum,
+    BlobShapeImpl,
+    DefaultBlobFactory,
+    DistributionEnum,
+    Geometry,
+    Model,
+)
 import matplotlib.pyplot as plt
 import numpy as np
-
-bf = DefaultBlobFactory(A_dist="deg", wp_dist="deg", vx_dist="deg", vy_dist="zeros")
 
 t_drain = np.linspace(2, 1, 100)
 
 tmp = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
-    blob_shape="exp",
-    t_drain=t_drain,
+    blob_shape=BlobShapeImpl(BlobShapeEnum.exp),
     num_blobs=10000,
-    blob_factory=bf,
+    blob_factory=DefaultBlobFactory(
+        A_dist=DistributionEnum.deg,
+        vy_dist=DistributionEnum.zeros,
+        t_drain=t_drain,
+    ),
 )
 
 ds_changing_t_drain = tmp.make_realization(speed_up=False)
 
 tmp = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
-    blob_shape="exp",
-    t_drain=2,
+    blob_shape=BlobShapeImpl(BlobShapeEnum.exp),
     num_blobs=10000,
-    blob_factory=bf,
+    blob_factory=DefaultBlobFactory(
+        A_dist=DistributionEnum.deg,
+        vy_dist=DistributionEnum.zeros,
+        t_drain=2,
+    ),
 )
 
 ds_constant_drain = tmp.make_realization(speed_up=False)

--- a/docs/create_logo.py
+++ b/docs/create_logo.py
@@ -22,7 +22,6 @@ class CustomBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> List[Blob]:
         # set custom parameter distributions
         amp = [1, 1, 1]
@@ -49,7 +48,7 @@ class CustomBlobFactory(BlobFactory):
                 pos_x0=posx[i],
                 pos_y0=posy[i],
                 t_init=t_init[i],
-                t_drain=t_drain,
+                t_drain=np.inf,
             )
             for i in range(num_blobs)
         ]
@@ -62,7 +61,6 @@ bf = CustomBlobFactory()
 tmp = Model(
     geometry=Geometry(Nx=64, Ny=64, Lx=10, Ly=10, dt=1, T=10, periodic_y=True),
     blob_shape="gauss",
-    t_drain=100000,
     num_blobs=3,
     blob_factory=bf,
 )

--- a/docs/drainage_time.rst
+++ b/docs/drainage_time.rst
@@ -3,7 +3,8 @@
 Drainage Time
 =============
 
-By default, the drainage time is set to a constant value in the whole domain. In this case ``t_drain`` is simply set to an integer or float.
+Blob draining is owned by the blob factory: ``DefaultBlobFactory`` takes a ``t_drain`` argument which it assigns to every sampled blob.
+By default ``t_drain`` is ``np.inf``, i.e. the blobs do not drain. Setting it to an integer or float gives a constant drainage time in the whole domain.
 We can also set ``t_drain`` to an array like of length ``Nx``. In this case ``t_drain`` will vary accordingly with x.
 
 Let's take a look at a quick example. Let's assume we want ``t_drain`` to decrease linearly with x. We could implement this as follows:

--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -10,13 +10,12 @@ from blobmodel import (
 
 # Example of a one-dimensional realization and animation.
 
-bf = DefaultBlobFactory(vy_dist=DistributionEnum.zeros)
+bf = DefaultBlobFactory(vy_dist=DistributionEnum.zeros, t_drain=10)
 
 bm = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=0.1, T=10, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.exp),
     num_blobs=20,
-    t_drain=10,
     blob_factory=bf,
     one_dimensional=True,
 )

--- a/examples/2_sided_exp_pulse.py
+++ b/examples/2_sided_exp_pulse.py
@@ -20,7 +20,6 @@ bm = Model(
     geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=10, periodic_y=True),
     num_blobs=10,
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.double_exp),
-    t_drain=1e10,
     blob_factory=bf,
 )
 

--- a/examples/2d_animation.py
+++ b/examples/2d_animation.py
@@ -7,7 +7,6 @@ bm = Model(
         Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=20, periodic_y=True, t_init=10
     ),
     num_blobs=100,
-    t_drain=1e10,
 )
 
 # Make a realization and store it in a DataSet object

--- a/examples/blob_tilting.py
+++ b/examples/blob_tilting.py
@@ -37,7 +37,6 @@ bm = Model(
     ),
     blob_shape=BlobShapeImpl(BlobShapeEnum.rect, BlobShapeEnum.rect),
     num_blobs=100,
-    t_drain=1e10,
     blob_factory=bf,
 )
 ds = bm.make_realization(speed_up=True, error=1e-2)
@@ -69,7 +68,6 @@ bm = Model(
     ),
     blob_shape=BlobShapeImpl(BlobShapeEnum.rect, BlobShapeEnum.rect),
     num_blobs=100,
-    t_drain=1e10,
     blob_factory=bf,
 )
 ds = bm.make_realization(speed_up=True, error=1e-2)

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -12,16 +12,15 @@ import numpy as np
 # Example of use of a spatially varying t_drain parameter. The results are compared with the case of constant
 # t_drain.
 
-bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros)
-
 t_drain = np.linspace(2, 1, 100)
 
 decreasing_t_drain = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-    t_drain=t_drain,
     num_blobs=10000,
-    blob_factory=bf,
+    blob_factory=DefaultBlobFactory(
+        A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
+    ),
 )
 
 ds_decreasing = decreasing_t_drain.make_realization(speed_up=True, error=1e-2)
@@ -30,9 +29,10 @@ ds_decreasing.n.isel(y=0).mean(dim=("t")).plot(label="decreasing t_drain")
 constant_t_drain = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-    t_drain=2,
     num_blobs=10000,
-    blob_factory=bf,
+    blob_factory=DefaultBlobFactory(
+        A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=2
+    ),
 )
 
 ds_constant = constant_t_drain.make_realization(speed_up=True, error=1e-2)

--- a/examples/compare_to_analytical_sol.py
+++ b/examples/compare_to_analytical_sol.py
@@ -16,14 +16,12 @@ import numpy as np
 bf = DefaultBlobFactory(
     A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, vy_parameter=10
 )
-t_drain = 1e10
 
 tmp = Model(
     geometry=Geometry(
         Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=10000, periodic_y=True, t_init=10
     ),
     blob_shape=BlobShapeImpl(BlobShapeEnum.gaussian, BlobShapeEnum.gaussian),
-    t_drain=1e10,
     num_blobs=10000,
     blob_factory=bf,
     one_dimensional=False,

--- a/examples/custom_blobfactory.py
+++ b/examples/custom_blobfactory.py
@@ -9,6 +9,11 @@ from blobmodel import (
 import numpy as np
 
 # Example of implementing a BlobFactory, which allows to set blob parameters in any desirable way.
+# For simpler cases you may not need a subclass at all:
+# - Model.from_blobs(blobs) realizes a pre-built list of Blob objects,
+# - CallableBlobFactory(blob_getter) builds each blob by calling
+#   blob_getter(rng), which keeps realizations seedable if the getter draws
+#   its random numbers from the rng it is given.
 
 
 # create custom class that inherits from BlobFactory

--- a/examples/custom_blobfactory.py
+++ b/examples/custom_blobfactory.py
@@ -19,9 +19,12 @@ import numpy as np
 # create custom class that inherits from BlobFactory
 # here you can define your custom parameter distributions
 class CustomBlobFactory(BlobFactory):
-    def __init__(self, seed=None) -> None:
-        # Draw random numbers from self.rng: a seed passed to Model replaces it
-        # (via BlobFactory.set_rng), making realizations reproducible.
+    def __init__(self, t_drain: float = np.inf, seed=None) -> None:
+        # Blob draining is owned by the factory: each sampled Blob gets this
+        # t_drain. Draw random numbers from self.rng: a seed passed to Model
+        # replaces it (via BlobFactory.set_rng), making realizations
+        # reproducible.
+        self.t_drain = t_drain
         self.rng = np.random.default_rng(seed)
 
     def sample_blobs(
@@ -30,7 +33,6 @@ class CustomBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> list[Blob]:
         # set custom parameter distributions
         amp = np.linspace(0.01, 1, num=num_blobs)
@@ -57,7 +59,7 @@ class CustomBlobFactory(BlobFactory):
                 pos_x0=posx[i],
                 pos_y0=posy[i],
                 t_init=t_init[i],
-                t_drain=t_drain,
+                t_drain=self.t_drain,
             )
             for i in range(num_blobs)
         ]
@@ -66,10 +68,9 @@ class CustomBlobFactory(BlobFactory):
         return False
 
 
-bf = CustomBlobFactory()
+bf = CustomBlobFactory(t_drain=2)
 tmp = Model(
     geometry=Geometry(Nx=32, Ny=32, Lx=10, Ly=10, dt=0.1, T=10, periodic_y=True),
-    t_drain=2,
     num_blobs=100,
     blob_factory=bf,
 )

--- a/examples/point_process.py
+++ b/examples/point_process.py
@@ -22,7 +22,6 @@ model = bm.Model(
     geometry=bm.Geometry(Nx=1, Ny=1, Lx=1, Ly=0, dt=dt, T=T, t_init=0),
     num_blobs=num_blobs,
     blob_shape=bm.BlobShapeImpl(bm.BlobShapeEnum.exp, bm.BlobShapeEnum.gaussian),
-    t_drain=1e10,
     blob_factory=bm.DefaultBlobFactory(
         A_dist=bm.DistributionEnum.exp, vy_dist=bm.DistributionEnum.zeros
     ),

--- a/examples/show_labels.py
+++ b/examples/show_labels.py
@@ -6,7 +6,6 @@ from blobmodel import Geometry, Model
 bm = Model(
     geometry=Geometry(Nx=100, Ny=100, Lx=20, Ly=20, dt=0.1, T=20, periodic_y=True),
     num_blobs=10,
-    t_drain=1e10,
     labels="individual",
 )
 

--- a/examples/single_blob.py
+++ b/examples/single_blob.py
@@ -9,7 +9,6 @@ from blobmodel import (
 bm = Model(
     geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=10, periodic_y=True),
     num_blobs=1,
-    t_drain=1e10,
 )
 
 # create data

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -11,14 +11,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 # use DefaultBlobFactory to define distribution functions fo random variables
-bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros)
-
 t_drain = 2
+bf = DefaultBlobFactory(
+    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
+)
+
 Nx, Lx = 10, 10
 tmp = Model(
     geometry=Geometry(Nx=Nx, Ny=1, Lx=Lx, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-    t_drain=t_drain,
     num_blobs=10000,
     blob_factory=bf,
     one_dimensional=True,

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -280,7 +280,6 @@ def test_get_blobs():
     bf = DefaultBlobFactory(A_dist=DistributionEnum.deg)
     model = Model(
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=1, T=1, periodic_y=False),
-        t_drain=1e10,
         num_blobs=3,
         blob_factory=bf,
     )
@@ -329,25 +328,19 @@ def test_theta_setter_overrides_factory_alignment():
     """A registered theta_setter wins over the factory's blob_alignment flag."""
     bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, blob_alignment=True)
     bf.set_theta_setter(lambda: 0.5)
-    blobs = bf.sample_blobs(
-        Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl(), t_drain=1e10
-    )
+    blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(b._theta == 0.5 for b in blobs)
 
 
 def test_factory_alignment_used_without_theta_setter():
     """Without a theta_setter, the factory falls back to blob_alignment (velocity phase)."""
     bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, blob_alignment=True)
-    blobs = bf.sample_blobs(
-        Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl(), t_drain=1e10
-    )
+    blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(np.isclose(b._theta, np.arctan2(b.v_y, b.v_x)) for b in blobs)
 
 
 def test_factory_default_is_axis_aligned():
     """With all-default arguments the factory produces untilted blobs (blob_alignment=False)."""
     bf = DefaultBlobFactory(A_dist=DistributionEnum.deg)
-    blobs = bf.sample_blobs(
-        Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl(), t_drain=1e10
-    )
+    blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(b._theta == 0 for b in blobs)

--- a/tests/test_blob_factories.py
+++ b/tests/test_blob_factories.py
@@ -1,0 +1,163 @@
+"""Tests for BlobListFactory, CallableBlobFactory and Model.from_blobs."""
+
+import numpy as np
+import warnings
+from blobmodel import (
+    Blob,
+    BlobListFactory,
+    BlobShapeImpl,
+    CallableBlobFactory,
+    Geometry,
+    Model,
+)
+
+
+def _make_blob(blob_id=0, v_y=0.0, t_drain=np.inf, amplitude=1.0):
+    return Blob(
+        blob_id=blob_id,
+        blob_shape=BlobShapeImpl(),
+        amplitude=amplitude,
+        width_p=1,
+        width_s=1,
+        v_x=1,
+        v_y=v_y,
+        pos_x0=0,
+        pos_y0=1,
+        t_init=0,
+        t_drain=t_drain,
+    )
+
+
+def _geometry():
+    return Geometry(Nx=8, Ny=8, Lx=2, Ly=2, dt=0.5, T=2)
+
+
+def test_blob_list_factory_returns_given_blobs():
+    """sample_blobs returns exactly the stored blobs; all arguments are ignored."""
+    blobs = [_make_blob(blob_id=i) for i in range(3)]
+    bf = BlobListFactory(blobs)
+    sampled = bf.sample_blobs(
+        Ly=10, T=10, num_blobs=1000, blob_shape=BlobShapeImpl(), t_drain=10
+    )
+    assert sampled == blobs
+
+
+def test_blob_list_factory_one_dimensional_inferred():
+    """is_one_dimensional is True exactly when every blob has v_y == 0."""
+    assert BlobListFactory([_make_blob(v_y=0), _make_blob(v_y=0)]).is_one_dimensional()
+    assert not BlobListFactory([_make_blob(v_y=1)]).is_one_dimensional()
+
+
+def test_one_dimensional_model_from_blobs_no_warning():
+    """A 1D model built from v_y == 0 blobs does not emit the 1D-factory warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Model.from_blobs(
+            [_make_blob()],
+            geometry=Geometry(Nx=8, Ny=1, Lx=2, Ly=0, dt=0.5, T=2),
+            one_dimensional=True,
+            verbose=False,
+        )
+
+
+def test_from_blobs_matches_explicit_model():
+    """Model.from_blobs produces the same realization as the verbose
+    trivial-factory + dummy-parameters construction it replaces."""
+    blobs = [_make_blob(blob_id=i, amplitude=a) for i, a in enumerate((1.0, 2.0))]
+    ds_shortcut = Model.from_blobs(
+        blobs, geometry=_geometry(), verbose=False
+    ).make_realization()
+    ds_explicit = Model(
+        geometry=_geometry(),
+        num_blobs=len(blobs),
+        blob_shape=BlobShapeImpl(),
+        t_drain=1e10,
+        blob_factory=BlobListFactory(blobs),
+        verbose=False,
+    ).make_realization()
+    np.testing.assert_array_equal(ds_shortcut.n.values, ds_explicit.n.values)
+
+
+def test_from_blobs_realization_is_repeatable():
+    """Realizing the same blob list twice gives identical density fields."""
+    blobs = [_make_blob()]
+    model = Model.from_blobs(blobs, geometry=_geometry(), verbose=False)
+    np.testing.assert_array_equal(
+        model.make_realization().n.values, model.make_realization().n.values
+    )
+
+
+def _random_blob_getter(rng):
+    return _make_blob(amplitude=rng.exponential(), v_y=0.0)
+
+
+def test_callable_factory_uses_num_blobs():
+    """The getter is called once per requested blob."""
+    bf = CallableBlobFactory(_random_blob_getter, seed=42)
+    sampled = bf.sample_blobs(
+        Ly=10, T=10, num_blobs=7, blob_shape=BlobShapeImpl(), t_drain=10
+    )
+    assert len(sampled) == 7
+
+
+def test_callable_factory_same_seed_same_blobs():
+    """Two factories with the same seed produce identical blobs."""
+    blobs_1 = CallableBlobFactory(_random_blob_getter, seed=42).sample_blobs(
+        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl(), t_drain=10
+    )
+    blobs_2 = CallableBlobFactory(_random_blob_getter, seed=42).sample_blobs(
+        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl(), t_drain=10
+    )
+    assert [b.amplitude for b in blobs_1] == [b.amplitude for b in blobs_2]
+
+
+def test_callable_factory_model_seed_overrides():
+    """A seed passed to Model replaces the factory's generator, making
+    realizations reproducible regardless of the factory's own seed."""
+
+    def _model(factory_seed):
+        return Model(
+            geometry=_geometry(),
+            num_blobs=10,
+            blob_factory=CallableBlobFactory(_random_blob_getter, seed=factory_seed),
+            verbose=False,
+            seed=42,
+        )
+
+    np.testing.assert_array_equal(
+        _model(factory_seed=1).make_realization().n.values,
+        _model(factory_seed=2).make_realization().n.values,
+    )
+
+
+def test_callable_factory_one_dimensional_flag():
+    """is_one_dimensional reflects the declared flag."""
+    assert not CallableBlobFactory(_random_blob_getter).is_one_dimensional()
+    assert CallableBlobFactory(
+        _random_blob_getter, one_dimensional=True
+    ).is_one_dimensional()
+
+
+def test_t_drain_inf_means_no_draining():
+    """t_drain=np.inf disables the exponential decay: a blob passing through
+    the domain keeps its full amplitude."""
+    geometry = Geometry(Nx=10, Ny=1, Lx=10, Ly=0, dt=1, T=10, periodic_y=False)
+    blob_inf = _make_blob(t_drain=np.inf)
+    ds = Model.from_blobs(
+        [blob_inf], geometry=geometry, one_dimensional=True, verbose=False
+    ).make_realization()
+    # The blob center sits at x = t; the peak amplitude must not decay.
+    peaks = ds.n.values[0, np.arange(10), np.arange(10)]
+    np.testing.assert_allclose(peaks, peaks[0])
+
+    # And it must exceed the equivalent draining blob at late times.
+    blob_drain = _make_blob(t_drain=1)
+    ds_drain = Model.from_blobs(
+        [blob_drain], geometry=geometry, one_dimensional=True, verbose=False
+    ).make_realization()
+    assert ds_drain.n.values[0, -1, -1] < ds.n.values[0, -1, -1]
+
+
+def test_model_accepts_t_drain_inf():
+    """Model validation accepts t_drain=np.inf (documented no-drain value)."""
+    Model(geometry=_geometry(), t_drain=np.inf, verbose=False)

--- a/tests/test_blob_factories.py
+++ b/tests/test_blob_factories.py
@@ -36,9 +36,7 @@ def test_blob_list_factory_returns_given_blobs():
     """sample_blobs returns exactly the stored blobs; all arguments are ignored."""
     blobs = [_make_blob(blob_id=i) for i in range(3)]
     bf = BlobListFactory(blobs)
-    sampled = bf.sample_blobs(
-        Ly=10, T=10, num_blobs=1000, blob_shape=BlobShapeImpl(), t_drain=10
-    )
+    sampled = bf.sample_blobs(Ly=10, T=10, num_blobs=1000, blob_shape=BlobShapeImpl())
     assert sampled == blobs
 
 
@@ -71,7 +69,6 @@ def test_from_blobs_matches_explicit_model():
         geometry=_geometry(),
         num_blobs=len(blobs),
         blob_shape=BlobShapeImpl(),
-        t_drain=1e10,
         blob_factory=BlobListFactory(blobs),
         verbose=False,
     ).make_realization()
@@ -94,19 +91,17 @@ def _random_blob_getter(rng):
 def test_callable_factory_uses_num_blobs():
     """The getter is called once per requested blob."""
     bf = CallableBlobFactory(_random_blob_getter, seed=42)
-    sampled = bf.sample_blobs(
-        Ly=10, T=10, num_blobs=7, blob_shape=BlobShapeImpl(), t_drain=10
-    )
+    sampled = bf.sample_blobs(Ly=10, T=10, num_blobs=7, blob_shape=BlobShapeImpl())
     assert len(sampled) == 7
 
 
 def test_callable_factory_same_seed_same_blobs():
     """Two factories with the same seed produce identical blobs."""
     blobs_1 = CallableBlobFactory(_random_blob_getter, seed=42).sample_blobs(
-        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl(), t_drain=10
+        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl()
     )
     blobs_2 = CallableBlobFactory(_random_blob_getter, seed=42).sample_blobs(
-        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl(), t_drain=10
+        Ly=10, T=10, num_blobs=10, blob_shape=BlobShapeImpl()
     )
     assert [b.amplitude for b in blobs_1] == [b.amplitude for b in blobs_2]
 
@@ -158,6 +153,12 @@ def test_t_drain_inf_means_no_draining():
     assert ds_drain.n.values[0, -1, -1] < ds.n.values[0, -1, -1]
 
 
-def test_model_accepts_t_drain_inf():
-    """Model validation accepts t_drain=np.inf (documented no-drain value)."""
-    Model(geometry=_geometry(), t_drain=np.inf, verbose=False)
+def test_default_factory_default_is_no_drain():
+    """DefaultBlobFactory defaults to t_drain=np.inf (documented no-drain
+    value), so Model() produces non-draining blobs."""
+    from blobmodel import DefaultBlobFactory
+
+    bf = DefaultBlobFactory()
+    assert bf.t_drain == np.inf
+    blobs = bf.sample_blobs(Ly=10, T=10, num_blobs=2, blob_shape=BlobShapeImpl())
+    assert all(b.t_drain == np.inf for b in blobs)

--- a/tests/test_changing_t_drain.py
+++ b/tests/test_changing_t_drain.py
@@ -9,14 +9,15 @@ from blobmodel import (
 import numpy as np
 
 # use DefaultBlobFactory to define distribution functions fo random variables
-bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros)
-
 t_drain = np.linspace(2, 1, 10)
+
+bf = DefaultBlobFactory(
+    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
+)
 
 tmp = Model(
     geometry=Geometry(Nx=10, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-    t_drain=t_drain,
     num_blobs=10000,
     blob_factory=bf,
 )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -164,6 +164,69 @@ def test_blob_factory():
     # PLACEHOLDER blob_factory_1
 
 
+def test_prebuilt_blobs():
+    # PLACEHOLDER prebuilt_blobs_0
+    from blobmodel import Blob, BlobShapeImpl, Geometry, Model
+    import numpy as np
+
+    blobs = [
+        Blob(
+            blob_id=i,
+            blob_shape=BlobShapeImpl(),
+            amplitude=1,
+            width_p=1,
+            width_s=1,
+            v_x=1,
+            v_y=0,
+            pos_x0=0,
+            pos_y0=pos_y0,
+            t_init=t_init,
+            t_drain=np.inf,  # no draining
+        )
+        for i, (pos_y0, t_init) in enumerate([(2, 0), (5, 2), (8, 4)])
+    ]
+
+    bm = Model.from_blobs(
+        blobs, geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=10)
+    )
+    ds = bm.make_realization()
+    # PLACEHOLDER prebuilt_blobs_1
+
+
+def test_callable_blob_factory():
+    # PLACEHOLDER callable_blob_factory_0
+    from blobmodel import Blob, BlobShapeImpl, CallableBlobFactory, Geometry, Model
+    import numpy as np
+
+    def blob_getter(rng: np.random.Generator) -> Blob:
+        # Draw random numbers from the generator you are given (not from the
+        # global np.random state) so that the realization is reproducible
+        # through CallableBlobFactory(seed=...) or Model(seed=...).
+        return Blob(
+            blob_id=0,
+            blob_shape=BlobShapeImpl(),
+            amplitude=rng.exponential(),
+            width_p=1,
+            width_s=1,
+            v_x=1,
+            v_y=0,
+            pos_x0=0,
+            pos_y0=rng.uniform(0, 10),
+            t_init=rng.uniform(0, 10),
+            t_drain=np.inf,
+        )
+
+    bf = CallableBlobFactory(blob_getter, seed=42)
+
+    bm = Model(
+        geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=10),
+        num_blobs=10,  # blob_getter is called num_blobs times
+        blob_factory=bf,
+    )
+    ds = bm.make_realization()
+    # PLACEHOLDER callable_blob_factory_1
+
+
 def test_custom_blob_factory():
     # PLACEHOLDER custom_blob_factory_0
     from blobmodel import BlobFactory, AbstractBlobShape, Blob, Geometry, Model

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -14,7 +14,6 @@ def test_getting_started(tmp_path, monkeypatch):
             Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=20, periodic_y=True, t_init=10
         ),
         num_blobs=100,
-        t_drain=1e10,
     )
     # PLACEHOLDER getting_started_1
     ds = bm.make_realization(file_name="example.nc")
@@ -26,13 +25,13 @@ def test_getting_started(tmp_path, monkeypatch):
 def test_drainage_time():
     # PLACEHOLDER drainage_time_0
     import numpy as np
-    from blobmodel import Geometry, Model
+    from blobmodel import DefaultBlobFactory, Geometry, Model
 
     t_drain = np.linspace(2, 1, 100)
 
     tmp = Model(
         geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
-        t_drain=t_drain,
+        blob_factory=DefaultBlobFactory(t_drain=t_drain),
         num_blobs=10,
     )
     tmp.make_realization()
@@ -55,13 +54,13 @@ def test_one_dim():
         wp_dist=DistributionEnum.deg,
         vx_dist=DistributionEnum.deg,
         vy_dist=DistributionEnum.zeros,
+        t_drain=10,
     )
 
     bm = Model(
         geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=0.1, T=10, periodic_y=False),
         blob_shape=BlobShapeImpl(BlobShapeEnum.exp),
         num_blobs=20,
-        t_drain=10,
         blob_factory=bf,
         one_dimensional=True,
     )
@@ -84,7 +83,6 @@ def test_blob_shapes():
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=10, periodic_y=True),
         num_blobs=10,
         blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.lorentz),
-        t_drain=1e10,
     )
     # PLACEHOLDER blob_shapes_1
     bf = DefaultBlobFactory(
@@ -99,7 +97,6 @@ def test_blob_shapes():
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=10),
         num_blobs=10,
         blob_shape=BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp),
-        t_drain=1e10,
         blob_factory=bf,
     )
     # PLACEHOLDER blob_shapes_2
@@ -135,7 +132,6 @@ def test_blob_labels():
         geometry=Geometry(Nx=10, Ny=10, Lx=20, Ly=20, dt=0.1, T=20, periodic_y=True),
         blob_shape=BlobShapeImpl(BlobShapeEnum.gaussian),
         num_blobs=10,
-        t_drain=1e10,
         labels="individual",
         label_border=0.75,
     )
@@ -151,12 +147,13 @@ def test_blob_factory():
     # PLACEHOLDER blob_factory_0
     from blobmodel import DefaultBlobFactory, DistributionEnum, Geometry, Model
 
-    my_blob_factory = DefaultBlobFactory(A_dist=DistributionEnum.normal, A_parameter=5)
+    my_blob_factory = DefaultBlobFactory(
+        A_dist=DistributionEnum.normal, A_parameter=5, t_drain=100
+    )
 
     bm = Model(
         geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=20),
         blob_factory=my_blob_factory,
-        t_drain=100,
         num_blobs=100,
     )
 
@@ -233,10 +230,12 @@ def test_custom_blob_factory():
     import numpy as np
 
     class CustomBlobFactory(BlobFactory):
-        def __init__(self, seed=None) -> None:
-            # Draw random numbers from self.rng: a seed passed to Model
-            # replaces it (via BlobFactory.set_rng), making realizations
-            # reproducible.
+        def __init__(self, t_drain: float = np.inf, seed=None) -> None:
+            # Blob draining is owned by the factory: each sampled Blob gets
+            # this t_drain. Draw random numbers from self.rng: a seed passed
+            # to Model replaces it (via BlobFactory.set_rng), making
+            # realizations reproducible.
+            self.t_drain = t_drain
             self.rng = np.random.default_rng(seed)
 
         def sample_blobs(
@@ -245,7 +244,6 @@ def test_custom_blob_factory():
             T: float,
             num_blobs: int,
             blob_shape: AbstractBlobShape,
-            t_drain: float,
         ) -> list[Blob]:
 
             # set custom parameter distributions
@@ -273,7 +271,7 @@ def test_custom_blob_factory():
                     pos_x0=posx[i],
                     pos_y0=posy[i],
                     t_init=t_init[i],
-                    t_drain=t_drain,
+                    t_drain=self.t_drain,
                 )
                 for i in range(num_blobs)
             ]
@@ -281,10 +279,9 @@ def test_custom_blob_factory():
         def is_one_dimensional(self) -> bool:
             return False
 
-    bf = CustomBlobFactory()
+    bf = CustomBlobFactory(t_drain=2)
     tmp = Model(
         geometry=Geometry(Nx=10, Ny=10, Lx=2, Ly=2, dt=0.1, T=10, periodic_y=True),
-        t_drain=2,
         num_blobs=10,
         blob_factory=bf,
     )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -103,7 +103,7 @@ class _ListBlobFactory(BlobFactory):
     def __init__(self, blobs):
         self._blobs = blobs
 
-    def sample_blobs(self, Ly, T, num_blobs, blob_shape, t_drain):
+    def sample_blobs(self, Ly, T, num_blobs, blob_shape):
         return self._blobs
 
     def is_one_dimensional(self):

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -147,23 +147,33 @@ def test_model_rejects_wrong_types():
         Model(blob_factory="default")
 
 
-def test_model_rejects_bad_t_drain():
+def test_factory_rejects_nonpositive_t_drain():
     """
-    Model raises ValueError for t_drain arrays of the wrong length and for
-    non-positive t_drain values.
+    DefaultBlobFactory raises ValueError for non-positive t_drain values
+    (t_drain moved from Model to the factory).
     """
     with pytest.raises(ValueError, match="t_drain"):
-        Model(
-            geometry=Geometry(Nx=5),
-            t_drain=np.ones(3),
-        )
+        DefaultBlobFactory(t_drain=-1)
     with pytest.raises(ValueError, match="t_drain"):
-        Model(t_drain=-1)
+        DefaultBlobFactory(t_drain=np.array([1.0, 0.0]))
+
+
+def test_realization_rejects_wrong_length_t_drain():
+    """
+    make_realization raises ValueError when a sampled blob carries an
+    array-valued t_drain whose length does not match the geometry's Nx.
+    """
+    model = Model(
+        geometry=Geometry(Nx=5, Ny=1, Lx=5, Ly=0, dt=1, T=2),
+        num_blobs=2,
+        blob_factory=DefaultBlobFactory(
+            t_drain=np.ones(3), vy_dist=DistributionEnum.zeros
+        ),
+        one_dimensional=True,
+        verbose=False,
+    )
     with pytest.raises(ValueError, match="t_drain"):
-        Model(
-            geometry=Geometry(Nx=2),
-            t_drain=np.array([1.0, 0.0]),
-        )
+        model.make_realization()
 
 
 def test_periodic_y_width_warning_fired_once_with_values():

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -15,7 +15,6 @@ class CustomBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> List[Blob]:
         return [
             Blob(
@@ -29,7 +28,7 @@ class CustomBlobFactory(BlobFactory):
                 pos_x0=0,
                 pos_y0=Ly / 2,
                 t_init=0,
-                t_drain=t_drain,
+                t_drain=np.inf,
             )
             for i in range(num_blobs)
         ]
@@ -50,7 +49,6 @@ def test_bloblabels(labels, speed_up):
         geometry=Geometry(Nx=5, Ny=1, Lx=5, Ly=5, dt=1, T=5, periodic_y=True),
         num_blobs=1,
         blob_factory=bf,
-        t_drain=1e10,
         labels=labels,
     )
     ds = bm.make_realization(speed_up=speed_up)

--- a/tests/test_one_dim.py
+++ b/tests/test_one_dim.py
@@ -10,12 +10,13 @@ from blobmodel import (
 import numpy as np
 
 # use DefaultBlobFactory to define distribution functions fo random variables
-bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros)
+bf = DefaultBlobFactory(
+    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=2
+)
 
 one_dim_model = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-    t_drain=2,
     num_blobs=10000,
     blob_factory=bf,
     one_dimensional=True,
@@ -56,7 +57,6 @@ def test_1d_geometry_mismatch_raises():
                 Nx=100, Ny=100, Lx=10, Ly=10, dt=1, T=1000, periodic_y=False
             ),
             blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
-            t_drain=2,
             num_blobs=1,
             blob_factory=bf,
             one_dimensional=True,

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -26,7 +26,7 @@ def _blob_attributes(blob):
 
 def _sample_default_blobs(factory, num_blobs=10):
     return factory.sample_blobs(
-        Ly=10, T=10, num_blobs=num_blobs, blob_shape=BlobShapeImpl(), t_drain=10
+        Ly=10, T=10, num_blobs=num_blobs, blob_shape=BlobShapeImpl()
     )
 
 

--- a/tests/test_speed_up.py
+++ b/tests/test_speed_up.py
@@ -39,7 +39,6 @@ class SingleBlobFactory(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> List[Blob]:
         return [Blob(blob_id=0, blob_shape=blob_shape, **self._params)]
 
@@ -70,7 +69,6 @@ def _make_model(
             x0=x0,
         ),
         blob_shape=BlobShapeImpl(BlobShapeEnum.gaussian, BlobShapeEnum.gaussian),
-        t_drain=1e10,
         num_blobs=1,
         blob_factory=factory,
         one_dimensional=True,
@@ -83,7 +81,6 @@ def _single_blob(factory: SingleBlobFactory) -> Blob:
         T=12,
         num_blobs=1,
         blob_shape=BlobShapeImpl(BlobShapeEnum.gaussian, BlobShapeEnum.gaussian),
-        t_drain=1e10,
     )[0]
 
 

--- a/tests/test_str.py
+++ b/tests/test_str.py
@@ -22,4 +22,4 @@ def test_model_str():
         blob_shape=BlobShapeImpl(),
         num_blobs=1,
     )
-    assert str(bm) == "2d Blob Model with num_blobs:1 and t_drain:10"
+    assert str(bm) == "2d Blob Model with num_blobs:1"

--- a/tests/test_vx_or_vy=0.py
+++ b/tests/test_vx_or_vy=0.py
@@ -20,7 +20,6 @@ class CustomBlobFactoryVy0(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> List[Blob]:
         # set custom parameter distributions
         _amp = np.ones(num_blobs)
@@ -44,7 +43,7 @@ class CustomBlobFactoryVy0(BlobFactory):
                 pos_x0=_posx[i],
                 pos_y0=_posy[i],
                 t_init=_t_init[i],
-                t_drain=t_drain,
+                t_drain=np.inf,
             )
             for i in range(num_blobs)
         ]
@@ -63,7 +62,6 @@ class CustomBlobFactoryVx0(BlobFactory):
         T: float,
         num_blobs: int,
         blob_shape: AbstractBlobShape,
-        t_drain: float,
     ) -> List[Blob]:
         # set custom parameter distributions
         _amp = np.ones(num_blobs)
@@ -87,7 +85,7 @@ class CustomBlobFactoryVx0(BlobFactory):
                 pos_x0=_posx[i],
                 pos_y0=_posy[i],
                 t_init=_t_init[i],
-                t_drain=t_drain,
+                t_drain=np.inf,
             )
             for i in range(num_blobs)
         ]
@@ -102,7 +100,6 @@ bm_vy_0 = Model(
     geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=1, T=1, periodic_y=True),
     num_blobs=1,
     blob_factory=bf_vy_0,
-    t_drain=1e10,
 )
 
 bf_vx_0 = CustomBlobFactoryVx0()
@@ -111,7 +108,6 @@ bm_vx_0 = Model(
     geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=1, T=1, periodic_y=True),
     num_blobs=1,
     blob_factory=bf_vx_0,
-    t_drain=1e10,
 )
 
 


### PR DESCRIPTION
Implements items 2 and 3 of the API-improvement work package (downstream-usage survey): make the dominant downstream workflow — hand-built `Blob` lists wrapped in a trivial factory plus dummy `Model` parameters — first-class API, and move blob draining to where it belongs.

Closes #93.

## What's new

- **`BlobListFactory`**: a `BlobFactory` that returns a pre-built blob list. All `sample_blobs` arguments are ignored (each `Blob` carries its own parameters). `is_one_dimensional()` is inferred from the blobs (`all(v_y == 0)`), so 1D use no longer emits the spurious "Are you sure you know what you are doing?" warning that every downstream `DeterministicBlobFactory` call currently triggers.
- **`CallableBlobFactory`**: builds each blob by calling `blob_getter(rng)` with the factory's `numpy.random.Generator`. This is the missing bridge that makes downstream `blob_getter` functions seedable through `CallableBlobFactory(seed=...)` or `Model(seed=...)` — today they all use global `np.random`, defeating the seeding machinery.
- **`Model.from_blobs(blobs, geometry=...)`**: shortcut for the pre-built-blobs case. The sampling parameters of `Model.__init__` no longer need to be supplied as dummies.
- **`t_drain` moved from `Model` to the factory** (breaking, resolves #93 fully): `Model` no longer takes `t_drain` and it is no longer threaded through `sample_blobs` — `BlobFactory.sample_blobs` drops its `t_drain` parameter. `DefaultBlobFactory` takes `t_drain` as a constructor argument (scalar or length-Nx array), defaulting to **`np.inf`**, the now-documented no-drain value (replacing the downstream folk convention `t_drain=1e10`/`1e100`). A bare `Model()` therefore produces non-draining blobs. Positivity is validated by the factory and `Blob`; the length-vs-Nx check for array-valued `t_drain` moves to `Model.make_realization`, validated per sampled blob against the geometry.

## Breaking changes (for the 2.0.0 batch)

- `Model(t_drain=...)` is gone → pass `DefaultBlobFactory(t_drain=...)`, or set `t_drain` per `Blob`.
- Custom `BlobFactory.sample_blobs` implementations must drop the `t_drain` parameter and own draining themselves.
- Default draining changed: `Model()` previously drained with `t_drain=10`; now it does not drain.

## Docs & tests

- New "Pre-built blobs: Model.from_blobs" and "CallableBlobFactory" sections in `docs/blob_factory.rst`, backed by executable snippets in `tests/test_docs.py` (PLACEHOLDER mechanism); `drainage_time.rst`, README, and all examples/docs scripts migrated (incl. repairing the dead `changing_t_drain_plot.py`).
- `tests/test_blob_factories.py`: list passthrough, 1D inference and warning suppression, `from_blobs` equivalence, `CallableBlobFactory` seeding/`Model` seed override/`num_blobs` use, `t_drain=np.inf` no-decay behavior, and the factory-default no-drain contract. Validation tests moved to the factory/realization level.
- Full suite: 170 passed; `black --check` and `mypy --ignore-missing-imports blobmodel` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
