### PR TITLE
Blob defaults and FPP-convention lam (feedback items 4 & 5)

### DIFF
--- a/blobmodel/blob_shape.py
+++ b/blobmodel/blob_shape.py
@@ -78,6 +78,19 @@ def _get_lorentz_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
 def _get_double_exponential_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
     """Compute the double-exponential pulse shape.
 
+    The shape is ``exp(-theta / lam)`` for ``theta >= 0`` and
+    ``exp(theta / (1 - lam))`` for ``theta < 0``, i.e. ``lam`` is the
+    e-folding fraction of the leading (``theta >= 0``) side of the pulse.
+    For a blob propagating with ``v_x > 0`` observed at a fixed position,
+    ``lam`` is therefore the temporal *rise* fraction of the measured pulse,
+    matching the asymmetry-parameter convention of the FPP literature.
+
+    .. versionchanged:: 2.0.0
+        The convention was flipped: ``lam`` previously weighted the trailing
+        (``theta < 0``) side, so ``lam`` was the temporal *fall* fraction.
+        Code written against older versions that passed ``1 - lam`` to
+        compensate should now pass ``lam`` directly.
+
     Parameters
     ----------
     theta : np.ndarray
@@ -86,9 +99,9 @@ def _get_double_exponential_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
         Additional keyword arguments.
         lam : float
             Asymmetry parameter controlling the shape, in the interval [0, 1].
-            The limits are the one-sided shapes: lam = 0 is a pure decay
-            (nonzero only for theta >= 0), lam = 1 a pure rise (nonzero only
-            for theta < 0).
+            The limits are the one-sided shapes: lam = 0 is nonzero only for
+            theta < 0 (a pure temporal decay for v_x > 0), lam = 1 is nonzero
+            only for theta >= 0 (a pure temporal rise for v_x > 0).
 
     Returns
     -------
@@ -104,10 +117,10 @@ def _get_double_exponential_shape(theta: np.ndarray, **kwargs) -> np.ndarray:
     if not 0.0 <= lam <= 1.0:
         raise ValueError(f"lam must be in the interval [0, 1], got lam = {lam}.")
     kern = np.zeros(shape=np.shape(theta))
-    if lam > 0.0:
-        kern[theta < 0] = np.exp(theta[theta < 0] / lam)
     if lam < 1.0:
-        kern[theta >= 0] = np.exp(-theta[theta >= 0] / (1 - lam))
+        kern[theta < 0] = np.exp(theta[theta < 0] / (1 - lam))
+    if lam > 0.0:
+        kern[theta >= 0] = np.exp(-theta[theta >= 0] / lam)
     return kern
 
 

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -3,7 +3,7 @@
 from typing import Union, Any, Optional
 from nptyping import NDArray
 import numpy as np
-from .blob_shape import AbstractBlobShape
+from .blob_shape import AbstractBlobShape, BlobShapeImpl
 import cmath
 
 
@@ -30,17 +30,17 @@ class Blob:
 
     def __init__(
         self,
-        blob_id: int,
-        blob_shape: AbstractBlobShape,
-        amplitude: float,
-        width_p: float,
-        width_s: float,
-        v_x: float,
-        v_y: float,
-        pos_x0: float,
-        pos_y0: float,
-        t_init: float,
-        t_drain: Union[float, NDArray],
+        blob_id: int = 0,
+        blob_shape: Optional[AbstractBlobShape] = None,
+        amplitude: float = 1.0,
+        width_p: float = 1.0,
+        width_s: float = 1.0,
+        v_x: float = 1.0,
+        v_y: float = 0.0,
+        pos_x0: float = 0.0,
+        pos_y0: float = 0.0,
+        t_init: float = 0.0,
+        t_drain: Union[float, NDArray] = np.inf,
         shape_parameters_p: Union[dict, None] = None,
         shape_parameters_s: Union[dict, None] = None,
         blob_alignment: bool = False,
@@ -51,28 +51,32 @@ class Blob:
 
         Parameters
         ----------
-        blob_id : int
-            Identifier for the blob.
-        blob_shape : AbstractBlobShape
-            Shape of the blob.
-        amplitude : float
-            Amplitude of the blob.
-        width_p : float
-            Width of the blob in the propagation direction.
-        width_s : float
-            Width of the blob in the perpendicular direction.
-        v_x : float
-            Velocity of the blob in the x-direction.
-        v_y : float
-            Velocity of the blob in the y-direction.
-        pos_x0 : float
-            Initial position of the blob in the x-direction.
-        pos_y0 : float
-            Initial position of the blob in the y-direction.
-        t_init : float
-            Initial time of the blob.
-        t_drain : Union[float, NDArray]
-            Time scale for the blob to drain. Use ``np.inf`` for no draining.
+        blob_id : int, optional
+            Identifier for the blob (default 0). Purely metadata: blob labels
+            in ``Model`` (``labels="individual"``) are assigned from each
+            blob's position in the factory output, not from ``blob_id``.
+        blob_shape : AbstractBlobShape, optional
+            Shape of the blob. Default None, which means a Gaussian shape in
+            both directions, ``BlobShapeImpl()``.
+        amplitude : float, optional
+            Amplitude of the blob. Default 1.
+        width_p : float, optional
+            Width of the blob in the propagation direction. Default 1.
+        width_s : float, optional
+            Width of the blob in the perpendicular direction. Default 1.
+        v_x : float, optional
+            Velocity of the blob in the x-direction. Default 1.
+        v_y : float, optional
+            Velocity of the blob in the y-direction. Default 0.
+        pos_x0 : float, optional
+            Initial position of the blob in the x-direction. Default 0.
+        pos_y0 : float, optional
+            Initial position of the blob in the y-direction. Default 0.
+        t_init : float, optional
+            Initial time of the blob. Default 0.
+        t_drain : Union[float, NDArray], optional
+            Time scale for the blob to drain. Default ``np.inf`` = no
+            draining.
         shape_parameters_p : dict
             Additional shape parameters for the propagation direction.
         shape_parameters_s : dict
@@ -96,6 +100,8 @@ class Blob:
             is not positive (every element, when it is an array).
 
         """
+        if blob_shape is None:
+            blob_shape = BlobShapeImpl()
         if not isinstance(blob_shape, AbstractBlobShape):
             raise TypeError(
                 f"blob_shape must be an AbstractBlobShape, got {type(blob_shape).__name__}."

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -57,7 +57,8 @@ class Model:
             Blob label setting. Possible values: "off", "same", "individual".
             "off": no blob labels returned
             "same": regions where blobs are present are set to label 1
-            "individual": different blobs return individual labels
+            "individual": each blob gets its own label, 1..num_blobs in the
+            order the factory returns the blobs
             Used for creating training data for supervised machine learning algorithms
         label_border : float, optional
             Defines region of blob as region where density >= label_border * amplitude of Blob
@@ -309,8 +310,8 @@ class Model:
         iterable = (
             tqdm(self._blobs, desc="Summing up Blobs") if self._verbose else self._blobs
         )
-        for blob in iterable:
-            self._sum_up_blobs(blob, speed_up, error)
+        for blob_index, blob in enumerate(iterable):
+            self._sum_up_blobs(blob, blob_index, speed_up, error)
 
         dataset = self._create_xr_dataset()
 
@@ -359,6 +360,7 @@ class Model:
     def _sum_up_blobs(
         self,
         blob: Blob,
+        blob_index: int,
         speed_up: bool,
         error: float,
     ):
@@ -369,6 +371,9 @@ class Model:
         ----------
         blob : Blob
             Blob object.
+        blob_index : int
+            Position of the blob in the factory output; used to assign the
+            blob label when ``labels="individual"``.
         speed_up : bool
             Flag for speeding up the code by discretizing each single blob at a smaller time window.
         error : float
@@ -400,7 +405,7 @@ class Model:
             __max_amplitudes[__max_amplitudes == 0] = np.inf
             self._labels_field[:, :, _start:_stop][
                 _single_blob >= __max_amplitudes * self._label_border
-            ] = (blob.blob_id + 1)
+            ] = (blob_index + 1)
 
     def _compute_start_stop(self, blob: Blob, speed_up: bool, error: float):
         """

--- a/docs/blob_shapes.rst
+++ b/docs/blob_shapes.rst
@@ -38,7 +38,7 @@ direction, respectively. These arguments are ``BlobShapeEnum`` typed, and can ta
      - Rectangular
    * - :math:`e^\theta \Theta(-\theta)`
      - :math:`\frac{1}{\pi(1+\theta^2)}`
-     - :math:`e^{\theta/\lambda} \Theta(-\theta) + e^{\theta/(1-\lambda)} \Theta(\theta)`
+     - :math:`e^{\theta/(1-\lambda)} \Theta(-\theta) + e^{-\theta/\lambda} \Theta(\theta)`
      - :math:`\frac{e^{-\theta^2/2}}{\sqrt{\pi}}`
      - :math:`\frac{2}{\pi (e^\theta + e^{-\theta})}`
      - :math:`\frac{-2 \theta e^{-\theta^2}}{\sqrt{\pi}}`
@@ -61,12 +61,21 @@ Two-sided exponential blob shape
 ++++++++++++++++++++++++++++++++
 
 The last blob shape we discuss is the two-sided exponential blob shape. In contrast to the shapes above, it requires an asymmetry parameter ``lam`` to specify the exact shape.
-The shape is implemented as follows:
+The shape is implemented as follows (``theta`` is the spatial coordinate in the blob frame):
 
 .. code-block:: python
 
-  shape[t < 0] = np.exp(t[t < 0] / lam)
-  shape[t >= 0] = np.exp(-t[t >= 0] / (1 - lam))
+  shape[theta < 0] = np.exp(theta[theta < 0] / (1 - lam))
+  shape[theta >= 0] = np.exp(-theta[theta >= 0] / lam)
+
+``lam`` weights the leading (``theta >= 0``) side of the pulse. For a blob propagating with
+``v_x > 0`` recorded at a fixed position, ``lam`` is the temporal *rise* fraction of the
+measured pulse — the standard asymmetry-parameter convention of the FPP literature.
+
+.. note::
+   The convention was flipped in blobmodel 2.0.0: previously ``lam`` weighted the
+   trailing (``theta < 0``) side, i.e. the temporal fall. Code written against older
+   versions that passed ``1 - lam`` to compensate should now pass ``lam`` directly.
 
 .. image:: 2-sided_pulse_shape.png
    :scale: 80%

--- a/docs/plot_pulses.py
+++ b/docs/plot_pulses.py
@@ -22,8 +22,8 @@ plt.show()
 
 for lam in [0.2, 0.5, 0.8]:
     shape = np.zeros(1000)
-    shape[t < 0] = np.exp(t[t < 0] / lam)
-    shape[t >= 0] = np.exp(-t[t >= 0] / (1 - lam))
+    shape[t < 0] = np.exp(t[t < 0] / (1 - lam))
+    shape[t >= 0] = np.exp(-t[t >= 0] / lam)
     plt.plot(t, shape, label=f"lam = {lam}")
 
 plt.xlabel("t")

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -10,6 +10,26 @@ import numpy as np
 from unittest.mock import MagicMock
 
 
+def test_blob_defaults():
+    """
+    Tests that a Blob is constructible without arguments, with the documented
+    defaults: a unit-amplitude, unit-width Gaussian blob moving with v_x = 1
+    from the origin, without draining.
+    """
+    blob = Blob()
+    assert blob.blob_id == 0
+    assert isinstance(blob.blob_shape, BlobShapeImpl)
+    assert blob.amplitude == 1
+    assert blob.width_p == 1
+    assert blob.width_s == 1
+    assert blob.v_x == 1
+    assert blob.v_y == 0
+    assert blob.pos_x0 == 0
+    assert blob.pos_y0 == 0
+    assert blob.t_init == 0
+    assert blob.t_drain == np.inf
+
+
 def test_gaussian_blob():
     """
     Tests Gaussian blob discretization on a meshgrid.

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -121,20 +121,22 @@ def test_double_exp_lam_outside_unit_interval_raises():
 def test_double_exp_lam_limits_are_one_sided():
     """
     lam = 0 and lam = 1 are valid one-sided limits of the double-exponential
-    shape: a pure decay and a pure rise, respectively.
+    shape: nonzero only on the trailing (theta < 0) and leading (theta >= 0)
+    side, respectively (a pure temporal decay and a pure temporal rise for a
+    blob with v_x > 0).
     """
     ps = BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp)
     theta = np.linspace(-5, 5, 100)
 
-    pure_decay = ps.get_blob_shape_p(theta, lam=0)
-    expected_decay = np.zeros_like(theta)
-    expected_decay[theta >= 0] = np.exp(-theta[theta >= 0])
-    np.testing.assert_allclose(pure_decay, expected_decay)
+    pure_trailing = ps.get_blob_shape_p(theta, lam=0)
+    expected_trailing = np.zeros_like(theta)
+    expected_trailing[theta < 0] = np.exp(theta[theta < 0])
+    np.testing.assert_allclose(pure_trailing, expected_trailing)
 
-    pure_rise = ps.get_blob_shape_p(theta, lam=1)
-    expected_rise = np.zeros_like(theta)
-    expected_rise[theta < 0] = np.exp(theta[theta < 0])
-    np.testing.assert_allclose(pure_rise, expected_rise)
+    pure_leading = ps.get_blob_shape_p(theta, lam=1)
+    expected_leading = np.zeros_like(theta)
+    expected_leading[theta >= 0] = np.exp(-theta[theta >= 0])
+    np.testing.assert_allclose(pure_leading, expected_leading)
 
 
 def test_model_rejects_wrong_types():

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -65,3 +65,23 @@ def test_bloblabels(labels, speed_up):
     )
     diff = ds["blob_labels"].values - correct_labels
     assert np.max(diff) < 0.00001
+
+
+def test_individual_labels_ignore_blob_id():
+    """
+    labels="individual" assigns labels 1..num_blobs from each blob's position
+    in the factory output, so hand-built blobs sharing the default blob_id=0
+    still get distinct labels.
+    """
+    warnings.filterwarnings("ignore")
+    blobs = [Blob(t_init=0), Blob(t_init=2)]
+    assert blobs[0].blob_id == blobs[1].blob_id == 0
+    bm = Model.from_blobs(
+        blobs=blobs,
+        geometry=Geometry(Nx=5, Ny=1, Lx=5, Ly=5, dt=1, T=5, periodic_y=True),
+        labels="individual",
+        verbose=False,
+    )
+    ds = bm.make_realization(speed_up=False)
+    labels_found = set(np.unique(ds["blob_labels"].values))
+    assert {1.0, 2.0} <= labels_found

--- a/tests/test_pulse_shape.py
+++ b/tests/test_pulse_shape.py
@@ -1,6 +1,55 @@
 import pytest
-from blobmodel import AbstractBlobShape, BlobShapeImpl, BlobShapeEnum
+from blobmodel import AbstractBlobShape, Blob, BlobShapeImpl, BlobShapeEnum
 import numpy as np
+
+
+def test_double_exp_lam_weights_leading_side():
+    """
+    Locks the double-exponential asymmetry convention: lam is the e-folding
+    fraction of the leading (theta >= 0) side, so the shape is
+    exp(-theta / lam) for theta >= 0 and exp(theta / (1 - lam)) for
+    theta < 0 (the FPP-literature convention; flipped in 2.0.0).
+    """
+    lam = 0.2
+    theta = np.arange(-10, 10, 0.1)
+    expected_values = np.zeros(len(theta))
+    expected_values[theta < 0] = np.exp(theta[theta < 0] / (1 - lam))
+    expected_values[theta >= 0] = np.exp(-theta[theta >= 0] / lam)
+
+    ps = BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp)
+    values = ps.get_blob_shape_p(theta, lam=lam)
+    np.testing.assert_allclose(values, expected_values)
+
+
+def test_double_exp_lam_is_temporal_rise_fraction():
+    """
+    For a blob propagating with v_x > 0 observed at a fixed position, lam is
+    the e-folding time fraction of the temporal *rise* of the measured pulse
+    and 1 - lam that of the fall.
+    """
+    lam = 0.2
+    blob = Blob(
+        blob_shape=BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.gaussian),
+        shape_parameters_p={"lam": lam},
+    )
+    x_probe = 10.0
+    t = np.linspace(0, 20, 501)
+    signal = blob.discretize_blob(
+        x=np.array(x_probe)[np.newaxis, np.newaxis, np.newaxis],
+        y=np.array(0.0)[np.newaxis, np.newaxis, np.newaxis],
+        t=t[np.newaxis, np.newaxis, :],
+        Ly=0,
+        one_dimensional=True,
+    )[0, 0, :]
+    # Default blob: amplitude 1, width_p 1, v_x 1, t_init 0, so the blob
+    # center passes the probe at t = x_probe. Before that the signal rises
+    # with time scale lam, after it falls with time scale 1 - lam.
+    expected = np.where(
+        t <= x_probe,
+        np.exp(-(x_probe - t) / lam),
+        np.exp(-(t - x_probe) / (1 - lam)),
+    )
+    np.testing.assert_allclose(signal, expected)
 
 
 def test_gauss_pulse_shape():
@@ -21,8 +70,8 @@ def test_kwargs():
     lam = 0.5
     x = np.arange(-10, 10, 0.1)
     expected_values = np.zeros(len(x))
-    expected_values[x < 0] = np.exp(x[x < 0] / lam)
-    expected_values[x >= 0] = np.exp(-x[x >= 0] / (1 - lam))
+    expected_values[x < 0] = np.exp(x[x < 0] / (1 - lam))
+    expected_values[x >= 0] = np.exp(-x[x >= 0] / lam)
 
     ps = BlobShapeImpl(BlobShapeEnum.double_exp, BlobShapeEnum.double_exp)
     values = ps.get_blob_shape_s(x, lam=0.5)


### PR DESCRIPTION
Implements items 4 and 5 of the API-improvement work package.

## Blob defaults (item 4)

- Every `Blob.__init__` parameter now has a default: `blob_id=0`, `blob_shape=None -> BlobShapeImpl()` (Gaussian), `amplitude=1`, `width_p=1`, `width_s=1`, `v_x=1`, `v_y=0`, `pos_x0=0`, `pos_y0=0`, `t_init=0`, `t_drain=np.inf`. Parameter order is unchanged, so existing positional calls keep working; a unit blob is now simply `Blob()` and the downstream `get_blob()`-style default-supplying wrappers become unnecessary.
- `labels="individual"` now assigns labels `1..num_blobs` from each blob's position in the factory output instead of `blob.blob_id + 1`, so hand-built blob lists sharing the default `blob_id=0` still get distinct labels. For `DefaultBlobFactory` (sequential ids) the labels are identical to before. `blob_id` is retained as pure metadata.

## `lam` convention flip (item 5, **breaking**)

The `double_exp` asymmetry parameter `lam` now weights the **leading** (`theta >= 0`) side of the spatial pulse:

```
shape[theta < 0]  = exp(theta / (1 - lam))
shape[theta >= 0] = exp(-theta / lam)
```

For a blob propagating with `v_x > 0` observed at a fixed position, `lam` is therefore the temporal **rise** fraction of the measured pulse — the standard FPP-literature convention. Previously `lam` weighted the trailing side (temporal fall), which is why downstream code had to pass `1 - lam` with a "defined in the opposite branch" comment; those workarounds must be removed when migrating. `BlobShapeImpl` docs, `docs/blob_shapes.rst` (whose old formula also had a sign error in the trailing branch) and `docs/plot_pulses.py` are updated, with a `versionchanged` note.

Part of the 2.0.0 breaking-change window (with #152/#153); version bump still pending.

## Tests

- `test_blob_defaults` — `Blob()` constructs with the documented defaults.
- `test_individual_labels_ignore_blob_id` — distinct labels for hand-built lists with default ids.
- `test_double_exp_lam_weights_leading_side` — locks the new spatial formula for asymmetric `lam`.
- `test_double_exp_lam_is_temporal_rise_fraction` — a moving blob measured at a fixed probe rises with time scale `lam` and falls with `1 - lam`.
- Existing one-sided-limit and kwargs tests updated to the new convention.

Full suite: 174 passed. `black --check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)