### PR TITLE
Add imaging output layout (feedback item 6)

### DIFF
--- a/blobmodel/__init__.py
+++ b/blobmodel/__init__.py
@@ -1,4 +1,4 @@
-from .model import Model
+from .model import Model, to_imaging_dataset
 from .blobs import Blob
 from .plotting import show_model
 from .stochasticality import (

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -231,6 +231,7 @@ class Model:
         file_name: Union[str, None] = None,
         speed_up: bool = False,
         error: float = 1e-10,
+        layout: str = "default",
     ) -> xr.Dataset:
         """
         Integrate the Model over time and write out data as an xarray dataset.
@@ -244,6 +245,12 @@ class Model:
             when blob values fall under given error value the blob gets discarded
         error : float, optional
             Numerical error at x = Lx when the blob gets truncated.
+        layout : str, optional
+            Layout of the returned (and saved) dataset. Possible values:
+            "default": density `n(y, x, t)` with 1D coordinates `x`, `y`, `t`.
+            "imaging": the GPI/APD imaging format `frames(y, x, time)` with
+            2D coordinates `R(y, x)`, `Z(y, x)`, as returned by
+            `to_imaging_dataset`. Requires a two-dimensional geometry.
 
         Returns
         -------
@@ -256,12 +263,16 @@ class Model:
             The resulting blob density, evaluated in the grid, is given by the `DataArray`, `n`, with
             dimension order (y, x, t), i.e. shape (Ny, Nx, Nt). In case that
             the model is one-dimensional, the vertical coordinate `y` will be of length 1.
+            With ``layout="imaging"`` the density is instead the `DataArray`
+            `frames` with dimensions (y, x, time), see `to_imaging_dataset`.
 
 
         Raises
         ------
         ValueError
-            If a sampled blob has an array-valued t_drain whose length does
+            If ``layout`` is not one of the values listed above, if
+            ``layout="imaging"`` is requested for a one-dimensional model, or
+            if a sampled blob has an array-valued t_drain whose length does
             not match the geometry's Nx.
 
         Warns
@@ -275,6 +286,15 @@ class Model:
         -----
         - speed_up is only a good approximation for blob_shape="exp"
         """
+        # Validate the layout before doing any expensive work.
+        if layout not in {"default", "imaging"}:
+            raise ValueError(
+                f'layout must be "default" or "imaging", got layout = "{layout}".'
+            )
+        if layout == "imaging" and self._geometry.Ly == 0:
+            raise ValueError(
+                'layout="imaging" requires a two-dimensional geometry (Ly > 0).'
+            )
 
         # Reset density field
         self._reset_fields()
@@ -314,6 +334,8 @@ class Model:
             self._sum_up_blobs(blob, blob_index, speed_up, error)
 
         dataset = self._create_xr_dataset()
+        if layout == "imaging":
+            dataset = to_imaging_dataset(dataset)
 
         if file_name is not None:
             dataset.to_netcdf(file_name)
@@ -448,3 +470,54 @@ class Model:
             self._labels_field = np.zeros(
                 shape=(self._geometry.Ny, self._geometry.Nx, self._geometry.t.size)
             )
+
+
+def to_imaging_dataset(dataset: xr.Dataset) -> xr.Dataset:
+    """
+    Convert a blobmodel output dataset to the GPI/APD imaging format.
+
+    Downstream analysis tooling for experimental gas-puff-imaging (GPI) and
+    avalanche-photodiode (APD) data standardizes on a dataset with the density
+    stored as ``frames(y, x, time)`` and the grid stored as two-dimensional
+    coordinate arrays ``R(y, x)``, ``Z(y, x)``. This helper converts the
+    default blobmodel output ``n(y, x, t)`` (1D coordinates ``x``, ``y``,
+    ``t``) into that format. It is also available directly from the model via
+    ``make_realization(..., layout="imaging")``.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        Dataset as returned by `Model.make_realization` with the default
+        layout. Must be two-dimensional, i.e. contain a `y` coordinate.
+        A `blob_labels` variable, if present, is carried over.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with the density as `frames` with dimension order
+        (y, x, time), coordinates `R` and `Z` of shape (Ny, Nx) holding the
+        meshgrid of the `x` and `y` coordinates, and the coordinate `time`.
+
+    Raises
+    ------
+    ValueError
+        If the dataset has no `y` coordinate (one-dimensional model output).
+    """
+    if "y" not in dataset.coords:
+        raise ValueError(
+            "The imaging layout requires two-dimensional model output "
+            "with a y coordinate."
+        )
+    grid_r, grid_z = np.meshgrid(dataset.x.values, dataset.y.values)
+    data_vars = {"frames": (["y", "x", "time"], dataset.n.values)}
+    if "blob_labels" in dataset:
+        data_vars["blob_labels"] = (["y", "x", "time"], dataset.blob_labels.values)
+    return xr.Dataset(
+        data_vars,
+        coords={
+            "R": (["y", "x"], grid_r),
+            "Z": (["y", "x"], grid_z),
+            "time": (["time"], dataset.t.values),
+        },
+        attrs=dataset.attrs,
+    )

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,9 +49,14 @@ Such animation can be plotted with the following code:
 
 Here, all the blobs move with the same speed and have the same shape and size. We will learn how to set distribution functions for the blobs parameters in :ref:`parameter-distributions`
 
-The ``make_realization`` method returns the realization in the form of an `xarray dataset <https://docs.xarray.dev/en/stable/index.html>`_. 
+The ``make_realization`` method returns the realization in the form of an `xarray dataset <https://docs.xarray.dev/en/stable/index.html>`_.
 The superposed pulses are stored in the ``n`` variable of the dataset. The dimension coordinates are ``x``, ``y`` and
 ``t`` for the horizontal, vertical and time coordinate, respectively.
+
+If you work with analysis tooling that expects experimental gas-puff-imaging (GPI) data, pass ``layout="imaging"``
+to ``make_realization`` to instead obtain the dataset in the imaging format: the density stored as ``frames(y, x, time)``
+with two-dimensional coordinate arrays ``R(y, x)`` and ``Z(y, x)`` holding the grid. The same conversion is available
+for an already-computed dataset via ``blobmodel.to_imaging_dataset``.
 
 We can now analyse the data using the convenient xarray syntax, for example:
 

--- a/tests/test_imaging_layout.py
+++ b/tests/test_imaging_layout.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pytest
+import xarray as xr
+from blobmodel import Geometry, Model, to_imaging_dataset
+
+
+def make_model(labels="off", one_dimensional=False):
+    geometry = (
+        Geometry(Nx=4, Ny=1, Lx=4, Ly=0, dt=1, T=5, periodic_y=False)
+        if one_dimensional
+        else Geometry(Nx=4, Ny=3, Lx=4, Ly=3, dt=1, T=5, periodic_y=False)
+    )
+    return Model(
+        geometry=geometry,
+        num_blobs=2,
+        labels=labels,
+        one_dimensional=one_dimensional,
+        verbose=False,
+        seed=42,
+    )
+
+
+def test_imaging_layout_matches_downstream_conversion():
+    """
+    layout="imaging" returns exactly the dataset downstream repos build by
+    hand from the default layout: frames(y, x, time) with meshgrid R/Z
+    coordinates.
+    """
+    ds = make_model().make_realization(speed_up=True, error=1e-10)
+    grid_r, grid_z = np.meshgrid(ds.x.values, ds.y.values)
+    expected = xr.Dataset(
+        {"frames": (["y", "x", "time"], ds.n.values)},
+        coords={
+            "R": (["y", "x"], grid_r),
+            "Z": (["y", "x"], grid_z),
+            "time": (["time"], ds.t.values),
+        },
+    )
+
+    ds_imaging = make_model().make_realization(
+        speed_up=True, error=1e-10, layout="imaging"
+    )
+    xr.testing.assert_allclose(ds_imaging, expected)
+
+
+def test_to_imaging_dataset_converter():
+    """
+    The standalone converter produces the same dataset as the layout
+    argument, so already-computed datasets can be converted too.
+    """
+    ds = make_model().make_realization(speed_up=True, error=1e-10)
+    ds_imaging = make_model().make_realization(
+        speed_up=True, error=1e-10, layout="imaging"
+    )
+    xr.testing.assert_allclose(to_imaging_dataset(ds), ds_imaging)
+
+
+def test_imaging_layout_keeps_blob_labels():
+    """
+    A blob_labels variable is carried over to the imaging layout with the
+    renamed time dimension.
+    """
+    ds_imaging = make_model(labels="individual").make_realization(layout="imaging")
+    assert "blob_labels" in ds_imaging
+    assert ds_imaging.blob_labels.dims == ("y", "x", "time")
+
+
+def test_invalid_layout_raises():
+    with pytest.raises(ValueError, match="layout"):
+        make_model().make_realization(layout="bogus")
+
+
+def test_imaging_layout_rejects_one_dimensional():
+    """
+    The imaging format is inherently two-dimensional; both the model argument
+    and the converter reject 1D output.
+    """
+    model = make_model(one_dimensional=True)
+    with pytest.raises(ValueError, match="two-dimensional"):
+        model.make_realization(layout="imaging")
+
+    ds_1d = model.make_realization()
+    with pytest.raises(ValueError, match="two-dimensional"):
+        to_imaging_dataset(ds_1d)


### PR DESCRIPTION
Closes #132.

Downstream repos (`fusion_scripts`, `imaging_methods`) repeat the same ~10-line conversion at every call site to reshape blobmodel output into the experimental GPI/APD format:

```python
grid_r, grid_z = np.meshgrid(ds.x.values, ds.y.values)
ds = xr.Dataset({"frames": (["y", "x", "time"], ds.n.values)},
                coords={"R": (["y", "x"], grid_r), "Z": (["y", "x"], grid_z),
                        "time": (["time"], ds.t.values)})
```

This PR moves that conversion into blobmodel, in exactly one place:

- **`make_realization(..., layout="imaging")`** returns (and saves, when `file_name` is given) the dataset as `frames(y, x, time)` with 2D coordinates `R(y, x)`, `Z(y, x)` and a `time` coordinate — byte-for-byte the downstream conversion. `layout="default"` (the default) is unchanged, so this is non-breaking.
- **`to_imaging_dataset(ds)`** (exported) is the underlying converter, usable on already-computed/loaded datasets.
- A `blob_labels` variable is carried over to the imaging layout; `attrs` are preserved.
- The layout is validated before any expensive work; 1D output is rejected with a clear error (the imaging format is inherently 2D). The 1D-squeeze sub-item of feedback item 6 is left for a separate change.
- Documented in `getting_started.rst`; `blobmodel.model` autodoc picks up the new function.

## Tests

`tests/test_imaging_layout.py`:
- imaging layout equals the hand-rolled downstream conversion (`xr.testing.assert_allclose`)
- standalone converter equals the layout argument
- `blob_labels` carried over with renamed time dimension
- invalid layout and 1D model/dataset raise `ValueError`

Full suite: 179 passed. `black --check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)