### PR TITLE
Return 1D output already squeezed (rest of feedback item 6)

### DIFF
--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -261,8 +261,9 @@ class Model:
             - y: Vertical coordinate
             - t: Time coordinate
             The resulting blob density, evaluated in the grid, is given by the `DataArray`, `n`, with
-            dimension order (y, x, t), i.e. shape (Ny, Nx, Nt). In case that
-            the model is one-dimensional, the vertical coordinate `y` will be of length 1.
+            dimension order (y, x, t), i.e. shape (Ny, Nx, Nt). For a grid
+            with Ly = 0 (one-dimensional model), the `y` dimension is dropped
+            and `n` has dimensions (x, t).
             With ``layout="imaging"`` the density is instead the `DataArray`
             `frames` with dimensions (y, x, time), see `to_imaging_dataset`.
 
@@ -352,16 +353,22 @@ class Model:
             xarray dataset with the density field data.
         """
         if self._geometry.Ly == 0:
+            # 1D output: drop the size-1 y dimension entirely, so consumers
+            # get n(x, t) without having to .squeeze().
             dataset = xr.Dataset(
                 data_vars=dict(
-                    n=(["y", "x", "t"], self._density),
+                    n=(["x", "t"], self._density[0]),
                 ),
                 coords=dict(
                     x=(["x"], self._geometry.x),
                     t=(["t"], self._geometry.t),
                 ),
-                attrs=dict(description="2D propagating blobs."),
+                attrs=dict(description="1D propagating blobs."),
             )
+            if self._labels in {"same", "individual"}:
+                dataset = dataset.assign(
+                    blob_labels=(["x", "t"], self._labels_field[0])
+                )
         else:
             dataset = xr.Dataset(
                 data_vars=dict(
@@ -374,8 +381,10 @@ class Model:
                 ),
                 attrs=dict(description="2D propagating blobs."),
             )
-        if self._labels in {"same", "individual"}:
-            dataset = dataset.assign(blob_labels=(["y", "x", "t"], self._labels_field))
+            if self._labels in {"same", "individual"}:
+                dataset = dataset.assign(
+                    blob_labels=(["y", "x", "t"], self._labels_field)
+                )
 
         return dataset
 

--- a/blobmodel/plotting.py
+++ b/blobmodel/plotting.py
@@ -90,7 +90,9 @@ def show_model(
         im.set_data(data.isel(t=i).values)
         tx.set_text(f"t = {t_values[i]:.2f}")
 
-    if dataset.y.size == 1:
+    # 1D output (Ly = 0) has no y dimension at all; a 2D dataset with a
+    # single y point is also shown as a line plot.
+    if "y" not in dataset.dims or dataset.y.size == 1:
         line, tx = _setup_1d_plot(dataset=dataset, variable=variable)
         ani = animation.FuncAnimation(
             fig, animate_1d, frames=t_values.size, interval=interval

--- a/docs/changing_t_drain_plot.py
+++ b/docs/changing_t_drain_plot.py
@@ -39,8 +39,8 @@ ds_constant_drain = tmp.make_realization(speed_up=False)
 
 
 def plot_cahnging_t_drain(changing, constant):
-    changing.n.isel(y=0).mean(dim=("t")).plot(label="decreasing t_drain")
-    constant.n.isel(y=0).mean(dim=("t")).plot(label="constant t_drain")
+    changing.n.mean(dim=("t")).plot(label="decreasing t_drain")
+    constant.n.mean(dim=("t")).plot(label="constant t_drain")
     plt.yscale("log")
     plt.legend()
     plt.show()

--- a/docs/one_dim.rst
+++ b/docs/one_dim.rst
@@ -4,7 +4,8 @@ One Dimensional
 ===========
 
 The default behaviour of the ``Model`` is to draw two-dimensional realizations. It is possible to draw one-dimensional realizations too.
-This is achieved by setting the flag ``one_dimensional`` to True. Additionally, the vertical velocities should be set to zero:
+This is achieved by setting the flag ``one_dimensional`` to True. Additionally, the vertical velocities should be set to zero.
+The resulting dataset contains the density as ``n(x, t)`` — the ``y`` dimension is dropped entirely, so no ``squeeze()`` is needed:
 
 .. literalinclude:: ../tests/test_docs.py
    :language: python

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -24,7 +24,7 @@ decreasing_t_drain = Model(
 )
 
 ds_decreasing = decreasing_t_drain.make_realization(speed_up=True, error=1e-2)
-ds_decreasing.n.isel(y=0).mean(dim=("t")).plot(label="decreasing t_drain")
+ds_decreasing.n.mean(dim=("t")).plot(label="decreasing t_drain")
 
 constant_t_drain = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
@@ -36,7 +36,7 @@ constant_t_drain = Model(
 )
 
 ds_constant = constant_t_drain.make_realization(speed_up=True, error=1e-2)
-ds_constant.n.isel(y=0).mean(dim=("t")).plot(label="constant t_drain")
+ds_constant.n.mean(dim=("t")).plot(label="constant t_drain")
 
 plt.yscale("log")
 plt.legend()

--- a/examples/point_process.py
+++ b/examples/point_process.py
@@ -30,7 +30,7 @@ model = bm.Model(
 )
 ds = model.make_realization(speed_up=True, error=1e-10)
 ds = ds.isel(t=slice(start_index, int(1e50)))
-bm_signal = ds.n.isel(x=0, y=0).values
+bm_signal = ds.n.isel(x=0).values
 
 # Superposedpulses
 waiting_time = T / num_blobs

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -33,7 +33,7 @@ def test_convergence_to_analytical_solution():
     analytical derived results. See O. E. Garcia, et al.; Phys. Plasmas 1 May 2016; 23 (5): 052308. https://doi.org/10.1063/1.4951016
     """
     ds = tmp.make_realization(speed_up=True, error=1e-10)
-    model_profile = ds.n.isel(y=0).mean(dim="t")
+    model_profile = ds.n.mean(dim="t")
 
     x = np.arange(0, Lx, Lx / Nx)
     t_p = 1  # vx/ell

--- a/tests/test_blob_factories.py
+++ b/tests/test_blob_factories.py
@@ -142,7 +142,7 @@ def test_t_drain_inf_means_no_draining():
         [blob_inf], geometry=geometry, one_dimensional=True, verbose=False
     ).make_realization()
     # The blob center sits at x = t; the peak amplitude must not decay.
-    peaks = ds.n.values[0, np.arange(10), np.arange(10)]
+    peaks = ds.n.values[np.arange(10), np.arange(10)]
     np.testing.assert_allclose(peaks, peaks[0])
 
     # And it must exceed the equivalent draining blob at late times.
@@ -150,7 +150,7 @@ def test_t_drain_inf_means_no_draining():
     ds_drain = Model.from_blobs(
         [blob_drain], geometry=geometry, one_dimensional=True, verbose=False
     ).make_realization()
-    assert ds_drain.n.values[0, -1, -1] < ds.n.values[0, -1, -1]
+    assert ds_drain.n.values[-1, -1] < ds.n.values[-1, -1]
 
 
 def test_default_factory_default_is_no_drain():

--- a/tests/test_changing_t_drain.py
+++ b/tests/test_changing_t_drain.py
@@ -28,7 +28,7 @@ def test_decreasing_t_drain():
     Checks that models with variable t_drain run and lead to a results lower than the constant case.
     """
     ds = tmp.make_realization(speed_up=True, error=1e-2)
-    model_profile = ds.n.isel(y=0).mean(dim=("t"))
+    model_profile = ds.n.mean(dim=("t"))
 
     x = np.linspace(0, 10, 10)
     t_p = 1

--- a/tests/test_one_dim.py
+++ b/tests/test_one_dim.py
@@ -29,7 +29,7 @@ def test_one_dim_converges_to_analytical():
     O. E. Garcia et al. Phys. Plasmas 1 May 2016; 23 (5): 052308. https://doi.org/10.1063/1.4951016)
     """
     ds = one_dim_model.make_realization(speed_up=True, error=1e-2)
-    model_profile = ds.n.isel(y=0).mean(dim=("t"))
+    model_profile = ds.n.mean(dim=("t"))
 
     x = np.linspace(0, 10, 100)
     t_p = 1
@@ -61,6 +61,25 @@ def test_1d_geometry_mismatch_raises():
             blob_factory=bf,
             one_dimensional=True,
         )
+
+
+def test_one_dim_dataset_has_no_y_dim():
+    """
+    One-dimensional output (Ly = 0) is returned already squeezed: n(x, t)
+    without a y dimension, and blob_labels follows the same shape.
+    """
+    model = Model(
+        geometry=Geometry(Nx=10, Ny=1, Lx=10, Ly=0, dt=1, T=10, periodic_y=False),
+        num_blobs=2,
+        blob_factory=bf,
+        one_dimensional=True,
+        labels="individual",
+        verbose=False,
+    )
+    ds = model.make_realization()
+    assert ds.n.dims == ("x", "t")
+    assert "y" not in ds.dims
+    assert ds.blob_labels.dims == ("x", "t")
 
 
 def test_1d_default_geometry():

--- a/tests/test_show_model.py
+++ b/tests/test_show_model.py
@@ -49,6 +49,22 @@ def test_plot_1d(mock_show):
 
 
 @patch("matplotlib.pyplot.show")
+def test_plot_1d_squeezed(mock_show):
+    """
+    Checks that show model runs on true 1D output (Ly = 0), which has no y
+    dimension at all.
+    """
+    warnings.filterwarnings("ignore")
+    bm = Model(
+        geometry=Geometry(Nx=10, Ny=1, Lx=10, Ly=0, dt=0.1, T=1, periodic_y=False),
+        num_blobs=1,
+        one_dimensional=True,
+    )
+    show_model(dataset=bm.make_realization(), interval=100, gif_name=None, fps=10)
+    plt.close("all")
+
+
+@patch("matplotlib.pyplot.show")
 def test_show_false_does_not_block(mock_show):
     """
     show=False must not call plt.show(), so scripts and CI are not blocked.


### PR DESCRIPTION
Completes feedback item 6 (follow-up to #155): the 1D branch of `Model._create_xr_dataset` dropped the `y` *coordinate* but kept the size-1 `y` *dimension*, so every 1D consumer had to call `.squeeze()` or `isel(y=0)` on the output.

## Changes

- **Breaking (1D only):** `Ly=0` output is now returned already squeezed — the density is `n(x, t)` with no `y` dimension, and `blob_labels` follows the same shape. The dataset `description` attr now says "1D propagating blobs." 2D output is completely unchanged.
- `show_model` detects 1D output by the absence of a `y` dimension. Previously, animating true `Ly=0` output crashed on `dataset.y` (the coordinate never existed); a 2D dataset with a single `y` point still gets the line plot as before.
- `make_realization` docstring, `docs/one_dim.rst`, and the 1D examples/docs scripts (`point_process.py`, `changing_t_drain.py`, `changing_t_drain_plot.py`) updated to the new shape.

## Migration

Downstream code doing `ds.n.isel(y=0)` or `ds.squeeze()` on 1D output: `isel(y=0)` must be removed (raises on the missing dimension); a bare `.squeeze()` keeps working as a no-op.

Part of the 2.0.0 breaking-change window (#152, #154).

## Tests

- New `test_one_dim_dataset_has_no_y_dim` locks dims `("x", "t")` for `n` and `blob_labels`.
- New `test_plot_1d_squeezed` covers animating true `Ly=0` output (previously untested and broken).
- Existing 1D statistical/analytical tests updated to index the squeezed shape.

Full suite: 181 passed. `black --check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)