### PR TITLE
Misc API cleanup: speed_up default, truncation_error rename, get_blobs guard, burn-in docs

### DIFF
--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -212,25 +212,32 @@ class Model:
 
     def get_blobs(self) -> List[Blob]:
         """
-        Return the list of blobs.
+        Return the list of blobs summed up in the last realization.
 
         Returns
         -------
         List[Blob]
             List of Blob objects.
 
-        Notes
-        -----
-        - Note that if Model.sample_blobs has not been called, the list will be empty
+        Raises
+        ------
+        RuntimeError
+            If no blobs have been sampled yet. Blobs are sampled by
+            ``make_realization``; call it first.
 
         """
+        if not self._blobs:
+            raise RuntimeError(
+                "No blobs have been sampled yet: blobs are sampled by "
+                "make_realization(), call it first."
+            )
         return self._blobs
 
     def make_realization(
         self,
         file_name: Union[str, None] = None,
-        speed_up: bool = False,
-        error: float = 1e-10,
+        speed_up: bool = True,
+        truncation_error: float = 1e-10,
         layout: str = "default",
     ) -> xr.Dataset:
         """
@@ -241,10 +248,14 @@ class Model:
         file_name : str, optional
             File name for the .nc file containing data as an xarray dataset.
         speed_up : bool, optional
-            Flag for speeding up the code by discretizing each single blob at smaller time window
-            when blob values fall under given error value the blob gets discarded
-        error : float, optional
-            Numerical error at x = Lx when the blob gets truncated.
+            Speed up the code by summing up each blob only over the time
+            window where its amplitude on the grid exceeds
+            ``truncation_error``; the rest of the blob is discarded.
+            Enabled by default; set to False for blob shapes with
+            slowly-decaying tails (see Notes).
+        truncation_error : float, optional
+            Amplitude below which a blob is truncated when ``speed_up`` is
+            enabled.
         layout : str, optional
             Layout of the returned (and saved) dataset. Possible values:
             "default": density `n(y, x, t)` with 1D coordinates `x`, `y`, `t`.
@@ -285,7 +296,9 @@ class Model:
 
         Notes
         -----
-        - speed_up is only a good approximation for blob_shape="exp"
+        - The truncation window used by speed_up assumes an exponentially
+          decaying pulse shape (blob_shape="exp"). For shapes with more
+          slowly decaying tails (e.g. lorentz) pass ``speed_up=False``.
         """
         # Validate the layout before doing any expensive work.
         if layout not in {"default", "imaging"}:
@@ -332,7 +345,7 @@ class Model:
             tqdm(self._blobs, desc="Summing up Blobs") if self._verbose else self._blobs
         )
         for blob_index, blob in enumerate(iterable):
-            self._sum_up_blobs(blob, blob_index, speed_up, error)
+            self._sum_up_blobs(blob, blob_index, speed_up, truncation_error)
 
         dataset = self._create_xr_dataset()
         if layout == "imaging":
@@ -393,7 +406,7 @@ class Model:
         blob: Blob,
         blob_index: int,
         speed_up: bool,
-        error: float,
+        truncation_error: float,
     ):
         """
         Sum up the contribution of a single blob to the density field.
@@ -407,10 +420,10 @@ class Model:
             blob label when ``labels="individual"``.
         speed_up : bool
             Flag for speeding up the code by discretizing each single blob at a smaller time window.
-        error : float
-            Numerical error when the blob gets truncated.
+        truncation_error : float
+            Amplitude below which the blob is truncated.
         """
-        _start, _stop = self._compute_start_stop(blob, speed_up, error)
+        _start, _stop = self._compute_start_stop(blob, speed_up, truncation_error)
         # 1D coordinate arrays shaped to broadcast against each other as
         # (Ny, Nx, Nt) — avoids materializing three full meshgrids.
         _single_blob = blob.discretize_blob(
@@ -438,7 +451,7 @@ class Model:
                 _single_blob >= __max_amplitudes * self._label_border
             ] = (blob_index + 1)
 
-    def _compute_start_stop(self, blob: Blob, speed_up: bool, error: float):
+    def _compute_start_stop(self, blob: Blob, speed_up: bool, truncation_error: float):
         """
         Compute the start and stop indices for summing up the contribution of a single blob.
 
@@ -448,8 +461,8 @@ class Model:
             Blob object.
         speed_up : bool
             Flag for speeding up the code by discretizing each single blob at a smaller time window.
-        error : float
-            Numerical error when the blob gets truncated.
+        truncation_error : float
+            Amplitude below which the blob is truncated.
 
         Returns
         -------
@@ -464,7 +477,11 @@ class Model:
             blob.v_x * dt
         )
         idx_Lx = idx_x0 + self._geometry.Lx / (blob.v_x * dt)
-        margin = -blob.width_p * np.log(error * np.sqrt(np.pi)) / np.abs(blob.v_x * dt)
+        margin = (
+            -blob.width_p
+            * np.log(truncation_error * np.sqrt(np.pi))
+            / np.abs(blob.v_x * dt)
+        )
         start = int(np.clip(min(idx_x0, idx_Lx) - margin, 0, self._geometry.t.size))
         stop = int(np.clip(max(idx_x0, idx_Lx) + margin, 0, self._geometry.t.size))
 

--- a/docs/blob_factory.rst
+++ b/docs/blob_factory.rst
@@ -104,3 +104,22 @@ By assigning an array like to the variables ``amp``, ``width``, ``vx``, ``vy``, 
 .. note::
 
    When using ``CustomBlobFactory`` it is your responsibility to make sure all blob variables have the correct dimensions. Also, if you wish to normalize the parameters you have to do this manually.
+
+++++++++++++++++++++++++++
+Stationarity and burn-in
+++++++++++++++++++++++++++
+
+``DefaultBlobFactory`` samples blob arrival times uniformly in ``[0, T)``, the same window the output is computed on.
+Since no blobs have arrived before ``t = 0``, the first part of the realization is a transient in which the mean density is still building up towards its stationary value.
+A common workaround is to discard an initial time slice of the output, but this wastes computed data.
+
+Instead, sample the arrival times on ``[-burn_in, T)`` while keeping the output grid on ``[0, T)``:
+blobs born at negative times have already propagated into the domain when the output starts, so the realization is stationary from ``t = 0``.
+Blob ``t_init`` values may be negative and blobs that never reach the domain within the output window are handled (and, with the default ``speed_up``, skipped cheaply):
+
+.. literalinclude:: ../tests/test_docs.py
+   :language: python
+   :start-after: # PLACEHOLDER burn_in_0
+   :end-before: # PLACEHOLDER burn_in_1
+
+Note that ``num_blobs`` should be scaled by ``(T + burn_in) / T`` to keep the arrival rate — and thus the stationary mean density — unchanged.

--- a/docs/create_logo.py
+++ b/docs/create_logo.py
@@ -65,7 +65,7 @@ tmp = Model(
     blob_factory=bf,
 )
 
-ds = tmp.make_realization(speed_up=True, error=1e-1)
+ds = tmp.make_realization(truncation_error=1e-1)
 
 import matplotlib.pyplot as plt
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,9 +29,9 @@ If we provide a ``file_name`` to the ``make_realization`` method, it will store 
    :start-after: # PLACEHOLDER getting_started_1
    :end-before: # PLACEHOLDER getting_started_2
 
-The ``make_realization`` method can take two more arguments, ``speed_up`` and ``error``, which can be helpful for integrating very large datasets.
-By setting ``spee_up`` to ``True``, the code will truncate the blobs when the blob values fall under the given ``error`` value. 
-The code assumes an exponential shape for the blobs when calculating the truncation position (see :ref:`blob-shapes` for further details).
+The ``make_realization`` method can take two more arguments, ``speed_up`` and ``truncation_error``, which are helpful for integrating very large datasets.
+By default (``speed_up=True``), each blob is only summed up over the time window where its amplitude exceeds ``truncation_error`` (default ``1e-10``); the rest is discarded.
+The code assumes an exponential shape for the blobs when calculating the truncation position (see :ref:`blob-shapes` for further details), so pass ``speed_up=False`` for shapes with slowly decaying tails.
 Increasing the spatial resolution (the ``Nx`` and ``Ny`` arguments of the ``Geometry``) will lead to something like this:
 
 

--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -20,5 +20,5 @@ bm = Model(
     one_dimensional=True,
 )
 
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 show_model(dataset=ds, interval=100, gif_name="1d_animation.gif")

--- a/examples/2_sided_exp_pulse.py
+++ b/examples/2_sided_exp_pulse.py
@@ -23,7 +23,7 @@ bm = Model(
     blob_factory=bf,
 )
 
-ds = bm.make_realization(speed_up=True, error=1e-10)
+ds = bm.make_realization(truncation_error=1e-10)
 
 show_model(ds)
 

--- a/examples/2d_animation.py
+++ b/examples/2d_animation.py
@@ -10,6 +10,6 @@ bm = Model(
 )
 
 # Make a realization and store it in a DataSet object
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 # show animation and save as gif
 show_model(dataset=ds, interval=100, gif_name="2d_animation.gif", fps=10)

--- a/examples/analyse_output.py
+++ b/examples/analyse_output.py
@@ -12,7 +12,7 @@ if not os.path.isfile("./example.nc"):
         blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
         num_blobs=1000,
     )
-    bm.make_realization(file_name="example.nc", speed_up=True, error=1e-2)
+    bm.make_realization(file_name="example.nc", truncation_error=1e-2)
 
 # use xarray to open output
 ds = xr.open_dataset("example.nc")

--- a/examples/blob_tilting.py
+++ b/examples/blob_tilting.py
@@ -39,7 +39,7 @@ bm = Model(
     num_blobs=100,
     blob_factory=bf,
 )
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 # show animation and save as gif
 show_model(dataset=ds, interval=100, gif_name="alignment_true.gif", fps=10)
 
@@ -70,6 +70,6 @@ bm = Model(
     num_blobs=100,
     blob_factory=bf,
 )
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 # show animation and save as gif
 show_model(dataset=ds, interval=100, gif_name="alignment_false.gif", fps=10)

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -23,7 +23,7 @@ decreasing_t_drain = Model(
     ),
 )
 
-ds_decreasing = decreasing_t_drain.make_realization(speed_up=True, error=1e-2)
+ds_decreasing = decreasing_t_drain.make_realization(truncation_error=1e-2)
 ds_decreasing.n.mean(dim=("t")).plot(label="decreasing t_drain")
 
 constant_t_drain = Model(
@@ -35,7 +35,7 @@ constant_t_drain = Model(
     ),
 )
 
-ds_constant = constant_t_drain.make_realization(speed_up=True, error=1e-2)
+ds_constant = constant_t_drain.make_realization(truncation_error=1e-2)
 ds_constant.n.mean(dim=("t")).plot(label="constant t_drain")
 
 plt.yscale("log")

--- a/examples/compare_to_analytical_sol.py
+++ b/examples/compare_to_analytical_sol.py
@@ -27,7 +27,7 @@ tmp = Model(
     one_dimensional=False,
 )
 
-ds = tmp.make_realization(speed_up=True, error=1e-10)
+ds = tmp.make_realization(truncation_error=1e-10)
 
 mean = ds.n.mean(dim="t").values
 

--- a/examples/custom_blobfactory.py
+++ b/examples/custom_blobfactory.py
@@ -75,5 +75,5 @@ tmp = Model(
     blob_factory=bf,
 )
 
-ds = tmp.make_realization(speed_up=True, error=1e-1)
+ds = tmp.make_realization(truncation_error=1e-1)
 show_model(dataset=ds)

--- a/examples/point_process.py
+++ b/examples/point_process.py
@@ -28,7 +28,7 @@ model = bm.Model(
     verbose=True,
     one_dimensional=True,  # Checks vy = 0 and sets the y blob shape to 1.
 )
-ds = model.make_realization(speed_up=True, error=1e-10)
+ds = model.make_realization(truncation_error=1e-10)
 ds = ds.isel(t=slice(start_index, int(1e50)))
 bm_signal = ds.n.isel(x=0).values
 

--- a/examples/show_labels.py
+++ b/examples/show_labels.py
@@ -10,7 +10,7 @@ bm = Model(
 )
 
 # create data
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 
 import matplotlib.pyplot as plt
 

--- a/examples/single_blob.py
+++ b/examples/single_blob.py
@@ -12,7 +12,7 @@ bm = Model(
 )
 
 # create data
-ds = bm.make_realization(speed_up=True, error=1e-2)
+ds = bm.make_realization(truncation_error=1e-2)
 
 # show animation and save as gif
 show_model(dataset=ds, interval=100, gif_name="example.gif", fps=10)

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -32,7 +32,7 @@ def test_convergence_to_analytical_solution():
     Checks that the mean value of a one-dimensional realization with constant velocities agrees with the
     analytical derived results. See O. E. Garcia, et al.; Phys. Plasmas 1 May 2016; 23 (5): 052308. https://doi.org/10.1063/1.4951016
     """
-    ds = tmp.make_realization(speed_up=True, error=1e-10)
+    ds = tmp.make_realization(truncation_error=1e-10)
     model_profile = ds.n.mean(dim="t")
 
     x = np.arange(0, Lx, Lx / Nx)

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -7,6 +7,7 @@ from blobmodel import (
     DistributionEnum,
 )
 import numpy as np
+import pytest
 from unittest.mock import MagicMock
 
 
@@ -306,6 +307,19 @@ def test_get_blobs():
     model.make_realization()
     blob_list = model.get_blobs()
     assert len(blob_list) == 3
+
+
+def test_get_blobs_before_realization_raises():
+    """
+    get_blobs() before make_realization() has nothing to return; it must
+    raise instead of silently returning an empty list.
+    """
+    model = Model(
+        geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=1, T=1, periodic_y=False),
+        num_blobs=3,
+    )
+    with pytest.raises(RuntimeError, match="make_realization"):
+        model.get_blobs()
 
 
 def _make_blob(blob_alignment=False, theta=None):

--- a/tests/test_changing_t_drain.py
+++ b/tests/test_changing_t_drain.py
@@ -27,7 +27,7 @@ def test_decreasing_t_drain():
     """
     Checks that models with variable t_drain run and lead to a results lower than the constant case.
     """
-    ds = tmp.make_realization(speed_up=True, error=1e-2)
+    ds = tmp.make_realization(truncation_error=1e-2)
     model_profile = ds.n.mean(dim=("t"))
 
     x = np.linspace(0, 10, 10)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -64,7 +64,7 @@ def test_one_dim():
         blob_factory=bf,
         one_dimensional=True,
     )
-    bm.make_realization(speed_up=True, error=1e-2)
+    bm.make_realization(truncation_error=1e-2)
     # PLACEHOLDER one_dim_0
 
 
@@ -136,7 +136,7 @@ def test_blob_labels():
         label_border=0.75,
     )
 
-    ds = bm.make_realization(speed_up=True, error=1e-2)
+    ds = bm.make_realization(truncation_error=1e-2)
 
     ds["n"].isel(t=-1).plot()
     ds["blob_labels"].isel(t=-1).plot()
@@ -288,3 +288,30 @@ def test_custom_blob_factory():
 
     ds = tmp.make_realization()
     # PLACEHOLDER custom_blob_factory_1
+
+
+def test_burn_in():
+    # PLACEHOLDER burn_in_0
+    from blobmodel import Blob, CallableBlobFactory, Geometry, Model
+    import numpy as np
+
+    T = 10
+    burn_in = 5  # roughly a few blob transit/drain times
+
+    def blob_getter(rng: np.random.Generator) -> Blob:
+        # Arrivals sampled on [-burn_in, T): blobs born before t = 0 have
+        # already propagated into the domain when the output starts.
+        return Blob(
+            amplitude=rng.exponential(),
+            pos_y0=rng.uniform(0, 10),
+            t_init=rng.uniform(-burn_in, T),
+        )
+
+    bm = Model(
+        geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=T),
+        # scale num_blobs with T + burn_in to keep the arrival rate fixed
+        num_blobs=int(30 * (T + burn_in) / T),
+        blob_factory=CallableBlobFactory(blob_getter, seed=42),
+    )
+    ds = bm.make_realization()
+    # PLACEHOLDER burn_in_1

--- a/tests/test_imaging_layout.py
+++ b/tests/test_imaging_layout.py
@@ -26,7 +26,7 @@ def test_imaging_layout_matches_downstream_conversion():
     hand from the default layout: frames(y, x, time) with meshgrid R/Z
     coordinates.
     """
-    ds = make_model().make_realization(speed_up=True, error=1e-10)
+    ds = make_model().make_realization(truncation_error=1e-10)
     grid_r, grid_z = np.meshgrid(ds.x.values, ds.y.values)
     expected = xr.Dataset(
         {"frames": (["y", "x", "time"], ds.n.values)},
@@ -37,9 +37,7 @@ def test_imaging_layout_matches_downstream_conversion():
         },
     )
 
-    ds_imaging = make_model().make_realization(
-        speed_up=True, error=1e-10, layout="imaging"
-    )
+    ds_imaging = make_model().make_realization(truncation_error=1e-10, layout="imaging")
     xr.testing.assert_allclose(ds_imaging, expected)
 
 
@@ -48,10 +46,8 @@ def test_to_imaging_dataset_converter():
     The standalone converter produces the same dataset as the layout
     argument, so already-computed datasets can be converted too.
     """
-    ds = make_model().make_realization(speed_up=True, error=1e-10)
-    ds_imaging = make_model().make_realization(
-        speed_up=True, error=1e-10, layout="imaging"
-    )
+    ds = make_model().make_realization(truncation_error=1e-10)
+    ds_imaging = make_model().make_realization(truncation_error=1e-10, layout="imaging")
     xr.testing.assert_allclose(to_imaging_dataset(ds), ds_imaging)
 
 

--- a/tests/test_one_dim.py
+++ b/tests/test_one_dim.py
@@ -28,7 +28,7 @@ def test_one_dim_converges_to_analytical():
     Checks that one-dimensional realizations of the process agree with analytical results (see
     O. E. Garcia et al. Phys. Plasmas 1 May 2016; 23 (5): 052308. https://doi.org/10.1063/1.4951016)
     """
-    ds = one_dim_model.make_realization(speed_up=True, error=1e-2)
+    ds = one_dim_model.make_realization(truncation_error=1e-2)
     model_profile = ds.n.mean(dim=("t"))
 
     x = np.linspace(0, 10, 100)

--- a/tests/test_speed_up.py
+++ b/tests/test_speed_up.py
@@ -233,8 +233,22 @@ def test_speed_up_realization_matches_full_on_offset_domain(x0, blob_kwargs):
     """
     factory = SingleBlobFactory(**blob_kwargs)
     ds_full = _make_model(factory, x0=x0).make_realization(speed_up=False)
-    ds_fast = _make_model(factory, x0=x0).make_realization(speed_up=True, error=ERROR)
+    ds_fast = _make_model(factory, x0=x0).make_realization(truncation_error=ERROR)
     np.testing.assert_allclose(ds_fast.n.values, ds_full.n.values, atol=10 * ERROR)
+
+
+def test_make_realization_defaults_to_speed_up():
+    """
+    speed_up=True with truncation_error=1e-10 is the documented default
+    (every surveyed downstream call passed exactly this); a silent flip back
+    to False would go unnoticed by the other tests, which all pass the flag
+    explicitly.
+    """
+    import inspect
+
+    params = inspect.signature(Model.make_realization).parameters
+    assert params["speed_up"].default is True
+    assert params["truncation_error"].default == 1e-10
 
 
 @pytest.mark.parametrize("speed_up, v_x", [(False, 1.0), (True, 0.0)])

--- a/tests/test_vx_or_vy=0.py
+++ b/tests/test_vx_or_vy=0.py
@@ -112,8 +112,8 @@ bm_vx_0 = Model(
 
 
 def test_vy_0():
-    assert bm_vy_0.make_realization(speed_up=True, error=1e-2)
+    assert bm_vy_0.make_realization(truncation_error=1e-2)
 
 
 def test_vx_0():
-    assert bm_vx_0.make_realization(speed_up=True, error=1e-2)
+    assert bm_vx_0.make_realization(truncation_error=1e-2)


### PR DESCRIPTION
Implements items 7 and 9 of the API-improvement work package (downstream-usage survey).

## Item 7 — `speed_up` default and `error` rename

Every surveyed downstream call in `fusion_scripts` / `imaging-methods` passes exactly `speed_up=True, error=1e-10`; no call site uses the defaults. Now that the truncation math is fixed (#144) and property-tested:

- `make_realization(speed_up=True, truncation_error=1e-10)` is the new default.
- **Breaking**: `error` is renamed to `truncation_error` (no deprecation shim, consistent with the other pending-2.0.0 breaking changes).
- `speed_up=False` remains the opt-out for slowly-decaying (non-exponential) pulse shapes; the docstring/docs now say so explicitly.
- All internal call sites (tests, examples, docs scripts) updated; a signature test guards the new defaults.

## Item 9 — misc observations

- `get_blobs()` before `make_realization()` now raises `RuntimeError` instead of silently returning `[]` (with test).
- New **"Stationarity and burn-in"** docs section (`blob_factory.rst`, tested example): sample arrival times on `[-burn_in, T)` with `CallableBlobFactory` so the output is stationary from `t = 0`, replacing the discard-an-initial-slice workaround seen downstream.
- Fixed the `speed_up` paragraph in `getting_started.rst` (`spee_up` typo, stale semantics).
- The theta/`blob_alignment` observation is deferred to the feedback.txt item-2 work (`theta_update`); the 1D-example observation is already covered by `docs/one_dim.rst`.

## Migration notes (downstream)

- `make_realization(speed_up=True, error=X)` → `make_realization(truncation_error=X)` (or just `make_realization()` for the standard `1e-10`).
- Any `get_blobs()` call tolerating a pre-realization `[]` must move after `make_realization()`.

All 184 tests pass; `black --check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)