### PR TITLE
Rework DefaultBlobFactory config as set_sampler; fix and smoke-test docs plot scripts

### DIFF
--- a/blobmodel/__init__.py
+++ b/blobmodel/__init__.py
@@ -6,6 +6,7 @@ from .stochasticality import (
     BlobListFactory,
     CallableBlobFactory,
     DefaultBlobFactory,
+    ParameterSampler,
 )
 from .geometry import Geometry
 from .blob_shape import AbstractBlobShape, BlobShapeImpl, BlobShapeEnum

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -158,29 +158,35 @@ class CallableBlobFactory(BlobFactory):
         return self._one_dimensional
 
 
+ParameterSampler = Callable[[np.random.Generator, int], np.ndarray]
+"""Signature of a custom sampler for `DefaultBlobFactory.set_sampler`: called
+with the factory's random number generator and the number of blobs, returns
+one sampled value per blob."""
+
+
 class DefaultBlobFactory(BlobFactory):
     """Default implementation of BlobFactory.
 
-    Generates blob parameters for different possible random
-    distributions. All random variables are independent from each other
+    Samples each blob parameter independently. Every parameter defaults to a
+    degenerate (constant) distribution except the amplitude, which is
+    exponential with mean 1 (the canonical FPP choice). Individual parameters
+    are reconfigured with `set_sampler`, which accepts either a
+    `DistributionEnum` or an arbitrary sampling callable.
     """
+
+    # Configurable parameter names -> (default distribution, free parameter).
+    _DEFAULT_SAMPLERS = {
+        "amplitude": (DistributionEnum.exp, 1.0),
+        "wp": (DistributionEnum.deg, 1.0),
+        "ws": (DistributionEnum.deg, 1.0),
+        "vx": (DistributionEnum.deg, 1.0),
+        "vy": (DistributionEnum.deg, 1.0),
+        "spp": (DistributionEnum.deg, 0.5),
+        "sps": (DistributionEnum.deg, 0.5),
+    }
 
     def __init__(
         self,
-        A_dist: DistributionEnum = DistributionEnum.exp,
-        wp_dist: DistributionEnum = DistributionEnum.deg,
-        ws_dist: DistributionEnum = DistributionEnum.deg,
-        vx_dist: DistributionEnum = DistributionEnum.deg,
-        vy_dist: DistributionEnum = DistributionEnum.deg,
-        spp_dist: DistributionEnum = DistributionEnum.deg,
-        sps_dist: DistributionEnum = DistributionEnum.deg,
-        A_parameter: float = 1.0,
-        wp_parameter: float = 1.0,
-        ws_parameter: float = 1.0,
-        vx_parameter: float = 1.0,
-        vy_parameter: float = 1.0,
-        shape_param_p_parameter: float = 0.5,
-        shape_param_s_parameter: float = 0.5,
         t_drain: Union[float, NDArray, int] = np.inf,
         blob_alignment: bool = False,
         seed: Union[int, np.random.Generator, None] = None,
@@ -188,39 +194,13 @@ class DefaultBlobFactory(BlobFactory):
         """
         Default implementation of BlobFactory.
 
-        Generates blob parameters for different possible random distributions.
-        All random variables are independent from each other.
+        Blob parameter distributions are configured with `set_sampler`; the
+        defaults are an exponential amplitude with mean 1 and degenerate
+        (constant) distributions for everything else: widths and velocities 1,
+        shape parameters 0.5.
 
         Parameters
         ----------
-        A_dist : Distribution, optional
-            Distribution type for amplitude, by default "Distribution.exp"
-        wp_dist : Distribution, optional
-            Distribution type for width in the principal blob direction, by default "Distribution.deg"
-        ws_dist : Distribution, optional
-            Distribution type for width in the secondary blob direction, by default "Distribution.deg"
-        vx_dist : Distribution, optional
-            Distribution type for velocity in the x-direction, by default "Distribution.deg"
-        vy_dist : Distribution, optional
-            Distribution type for velocity in the y-direction, by default "Distribution.deg"
-        spp_dist : Distribution, optional
-            Distribution type for shape parameter in the principal blob direction, by default "Distribution.deg"
-        sps_dist : Distribution, optional
-            Distribution type for shape parameter in the secondary blob direction, by default "Distribution.deg"
-        A_parameter : float, optional
-            Free parameter for the amplitude distribution, by default 1.0
-        wp_parameter : float, optional
-            Free parameter for the width distribution in the principal direction, by default 1.0
-        ws_parameter : float, optional
-            Free parameter for the width distribution in the secondary direction, by default 1.0
-        vx_parameter : float, optional
-            Free parameter for the velocity distribution in the x-direction, by default 1.0
-        vy_parameter : float, optional
-            Free parameter for the velocity distribution in the y-direction, by default 1.0
-        shape_param_p_parameter : float, optional
-            Free parameter for the shape parameter distribution in the principal direction, by default 0.5
-        shape_param_s_parameter : float, optional
-            Free parameter for the shape parameter distribution in the secondary direction, by default 0.5
         t_drain : float or array-like, optional
             Drain time scale of the blobs (exponential decay), applied to every
             sampled blob. Can be a single value or an array-like of length Nx
@@ -239,10 +219,67 @@ class DefaultBlobFactory(BlobFactory):
             Note that a seed passed to `Model` takes precedence: it replaces
             this factory's generator via `set_rng`.
 
+        Raises
+        ------
+        ValueError
+            If `t_drain` is not positive.
+        """
+        if np.any(np.asarray(t_drain) <= 0):
+            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
+
+        # Per-parameter distribution (None for custom callables) and sampler.
+        self._dists: dict = {}
+        self._free_parameters: dict = {}
+        self._samplers: dict = {}
+        for parameter, (dist, free_parameter) in self._DEFAULT_SAMPLERS.items():
+            self.set_sampler(parameter, dist, free_parameter)
+
+        self.t_drain = t_drain
+        self.blob_alignment = blob_alignment
+        self.theta_setter: Union[Callable[[], float], None] = None
+        self.rng = np.random.default_rng(seed)
+
+    def set_sampler(
+        self,
+        parameter: str,
+        sampler: Union[DistributionEnum, ParameterSampler],
+        free_parameter: Union[float, None] = None,
+    ) -> "DefaultBlobFactory":
+        """
+        Configure how one blob parameter is sampled.
+
+        Parameters
+        ----------
+        parameter : str
+            Which blob parameter to configure. One of:
+            - "amplitude": blob amplitude
+            - "wp": width in the principal (propagation) blob direction
+            - "ws": width in the secondary (perpendicular) blob direction
+            - "vx": velocity in the x-direction
+            - "vy": velocity in the y-direction
+            - "spp": pulse shape parameter in the principal direction
+            - "sps": pulse shape parameter in the secondary direction
+        sampler : DistributionEnum or Callable[[np.random.Generator, int], np.ndarray]
+            Either one of the built-in distributions (see Notes), or a callable
+            drawing the values itself: it is called with the factory's random
+            number generator and the number of blobs and must return one value
+            per blob. Draw from the generator you are given (not the global
+            `np.random` state) so realizations stay reproducible through
+            `DefaultBlobFactory(seed=...)` or `Model(seed=...)`.
+        free_parameter : float, optional
+            Free parameter of the built-in distribution (see Notes), by
+            default 1.0. Only valid together with a `DistributionEnum`.
+
+        Returns
+        -------
+        DefaultBlobFactory
+            The factory itself, so calls can be chained:
+            ``DefaultBlobFactory().set_sampler("vy", DistributionEnum.zeros)``.
+
         Notes
         -----
         - The following distributions are implemented:
-            - exp: exponential distribution with mean 1
+            - exp: exponential distribution with mean `free_parameter`
             - gamma: gamma distribution with `free_parameter` as shape parameter and mean 1
             - normal: normal distribution with zero mean and `free_parameter` as scale parameter
             - uniform: uniform distribution with mean 1 and `free_parameter` as width,
@@ -257,65 +294,64 @@ class DefaultBlobFactory(BlobFactory):
         Raises
         ------
         TypeError
-            If a distribution argument is not a DistributionEnum member.
+            If `sampler` is neither a DistributionEnum member nor a callable.
         ValueError
-            If a width distribution (`wp_dist` or `ws_dist`) is uniform with
-            `free_parameter` > 2, which would produce negative blob widths,
-            or if `t_drain` is not positive.
-
+            If `parameter` is not one of the names listed above, if a width
+            (`wp` or `ws`) is uniform with `free_parameter` > 2 (which would
+            produce negative blob widths), or if `free_parameter` is combined
+            with a callable sampler.
         """
-        for name, dist in (
-            ("A_dist", A_dist),
-            ("wp_dist", wp_dist),
-            ("ws_dist", ws_dist),
-            ("vx_dist", vx_dist),
-            ("vy_dist", vy_dist),
-            ("spp_dist", spp_dist),
-            ("sps_dist", sps_dist),
-        ):
-            if not isinstance(dist, DistributionEnum):
-                raise TypeError(
-                    f"{name} must be a DistributionEnum, got {type(dist).__name__}."
-                )
-
-        for name, dist, parameter in (
-            ("wp", wp_dist, wp_parameter),
-            ("ws", ws_dist, ws_parameter),
-        ):
-            if dist == DistributionEnum.uniform and parameter > 2:
+        if parameter not in self._DEFAULT_SAMPLERS:
+            raise ValueError(
+                f"Unknown parameter '{parameter}', "
+                f"must be one of {sorted(self._DEFAULT_SAMPLERS)}."
+            )
+        if isinstance(sampler, DistributionEnum):
+            if free_parameter is None:
+                free_parameter = 1.0
+            if (
+                parameter in ("wp", "ws")
+                and sampler == DistributionEnum.uniform
+                and free_parameter > 2
+            ):
                 raise ValueError(
-                    f"{name}_parameter = {parameter} with {name}_dist = uniform would produce "
-                    f"negative blob widths: the uniform distribution has support "
-                    f"[1 - {name}_parameter / 2, 1 + {name}_parameter / 2], so {name}_parameter must be <= 2."
+                    f"free_parameter = {free_parameter} with a uniform {parameter} distribution "
+                    f"would produce negative blob widths: the uniform distribution has support "
+                    f"[1 - free_parameter / 2, 1 + free_parameter / 2], so free_parameter must be <= 2."
                 )
+            dist_function = DISTRIBUTIONS[sampler]
+            self._dists[parameter] = sampler
+            self._free_parameters[parameter] = free_parameter
+            self._samplers[parameter] = (
+                lambda rng, num_blobs, _dist_function=dist_function, _free_parameter=free_parameter: _dist_function(
+                    num_blobs, rng, free_param=_free_parameter
+                )
+            )
+        elif callable(sampler):
+            if free_parameter is not None:
+                raise ValueError(
+                    "free_parameter only applies to DistributionEnum samplers; "
+                    "a callable sampler takes no free parameter."
+                )
+            self._dists[parameter] = None
+            self._free_parameters[parameter] = None
+            self._samplers[parameter] = sampler
+        else:
+            raise TypeError(
+                f"sampler for '{parameter}' must be a DistributionEnum or a callable, "
+                f"got {type(sampler).__name__}."
+            )
+        return self
 
-        self.amplitude_dist = A_dist
-        self.width_p_dist = wp_dist
-        self.width_s_dist = ws_dist
-        self.velocity_x_dist = vx_dist
-        self.velocity_y_dist = vy_dist
-        self.shape_param_p_dist = spp_dist
-        self.shape_param_s_dist = sps_dist
-        self.amplitude_parameter = A_parameter
-        self.width_p_parameter = wp_parameter
-        self.width_s_parameter = ws_parameter
-        self.velocity_x_parameter = vx_parameter
-        self.velocity_y_parameter = vy_parameter
-        if np.any(np.asarray(t_drain) <= 0):
-            raise ValueError(f"t_drain must be positive, got t_drain = {t_drain}.")
-
-        self.shape_param_p_parameter = shape_param_p_parameter
-        self.shape_param_s_parameter = shape_param_s_parameter
-        self.t_drain = t_drain
-        self.blob_alignment = blob_alignment
-        self.theta_setter: Union[Callable[[], float], None] = None
-        self.rng = np.random.default_rng(seed)
-
-    def _draw_random_variables(
-        self, dist: DistributionEnum, free_parameter: float, num_blobs: int
-    ) -> np.ndarray:
-        """Draws random variables from a specified distribution."""
-        return DISTRIBUTIONS[dist](num_blobs, self.rng, free_param=free_parameter)
+    def _draw_random_variables(self, parameter: str, num_blobs: int) -> np.ndarray:
+        """Draw `num_blobs` values for one parameter from its sampler."""
+        values = np.asarray(self._samplers[parameter](self.rng, num_blobs))
+        if values.shape != (num_blobs,):
+            raise ValueError(
+                f"The sampler for '{parameter}' returned shape {values.shape}, "
+                f"expected ({num_blobs},)."
+            )
+        return values
 
     def sample_blobs(
         self,
@@ -357,29 +393,13 @@ class DefaultBlobFactory(BlobFactory):
                 f"blob_shape must be an AbstractBlobShape, got {type(blob_shape).__name__}."
             )
 
-        amps = self._draw_random_variables(
-            self.amplitude_dist,
-            self.amplitude_parameter,
-            num_blobs,
-        )
-        wxs = self._draw_random_variables(
-            self.width_p_dist, self.width_p_parameter, num_blobs
-        )
-        wys = self._draw_random_variables(
-            self.width_s_dist, self.width_s_parameter, num_blobs
-        )
-        vxs = self._draw_random_variables(
-            self.velocity_x_dist, self.velocity_x_parameter, num_blobs
-        )
-        vys = self._draw_random_variables(
-            self.velocity_y_dist, self.velocity_y_parameter, num_blobs
-        )
-        spxs = self._draw_random_variables(
-            self.shape_param_p_dist, self.shape_param_p_parameter, num_blobs
-        )
-        spys = self._draw_random_variables(
-            self.shape_param_s_dist, self.shape_param_s_parameter, num_blobs
-        )
+        amps = self._draw_random_variables("amplitude", num_blobs)
+        wxs = self._draw_random_variables("wp", num_blobs)
+        wys = self._draw_random_variables("ws", num_blobs)
+        vxs = self._draw_random_variables("vx", num_blobs)
+        vys = self._draw_random_variables("vy", num_blobs)
+        spxs = self._draw_random_variables("spp", num_blobs)
+        spys = self._draw_random_variables("sps", num_blobs)
         # For now, only a lambda parameter is implemented
         spxs_dict = [{"lam": s} for s in spxs]
         spys_dict = [{"lam": s} for s in spys]
@@ -432,6 +452,9 @@ class DefaultBlobFactory(BlobFactory):
         Notes
         -----
         - Perpendicular width parameters are irrelevant since perp shape should be ignored by the Bolb class.
+        - Only the built-in `DistributionEnum.zeros` distribution for "vy" is
+          recognized as one-dimensional; a custom callable sampler is assumed
+          two-dimensional even if it always returns zeros.
 
         """
-        return self.velocity_y_dist == DistributionEnum.zeros
+        return self._dists["vy"] == DistributionEnum.zeros

--- a/docs/blob_factory.rst
+++ b/docs/blob_factory.rst
@@ -11,15 +11,26 @@ should implement ``BlobFactory``. An implementation is provided by ``DefaultBlob
 DefaultBlobFactory
 ++++++++++++++++++
 
-We can use ``DefaultBlobFactory`` class in order to change the distribution functions of the following blob parameters:
+We can use the ``DefaultBlobFactory`` class in order to change the distribution functions of the following blob parameters:
 
-* Amplitudes
-* widths in x and y
-* velocities in x and y
-* pulse shape in x and y
-* blob alignment and tilt
+.. list-table::
+   :widths: 10 50
+   :header-rows: 0
 
-The distributions for these parameters are set with the ``*_dist`` arguments. The following distribution functions are implemented:
+   * - "amplitude"
+     - blob amplitude
+
+   * - "wp" / "ws"
+     - widths in the principal and secondary blob direction
+
+   * - "vx" / "vy"
+     - velocities in the x- and y-direction
+
+   * - "spp" / "sps"
+     - pulse shape parameters in the principal and secondary direction
+
+By default, the amplitude is exponentially distributed with mean 1 and all other parameters are constant (widths and velocities 1, shape parameters 0.5).
+Individual parameters are reconfigured with the ``set_sampler`` method, which takes the parameter name and either one of the built-in distributions or a custom sampling callable. The following distribution functions are implemented:
 
 .. list-table:: 
    :widths: 10 50
@@ -47,15 +58,22 @@ The distributions for these parameters are set with the ``*_dist`` arguments. Th
      - array of zeros
 
 As you can see, some of these distributions require an additional ``free_parameter`` to specify the distribution.
-This is done by the ``*_parameter`` arguments.
+This is passed as the third argument of ``set_sampler``. ``set_sampler`` returns the factory itself, so calls can be chained.
 
-Let's take a look at an example. Let's assume we want to sample the blob amplitudes from normal distribution with 5 as the scale parameter. 
-We chose the defualt distributions for all other blob parameters. We would set up the Model as follows:
+Let's take a look at an example. Let's assume we want to sample the blob amplitudes from a normal distribution with 5 as the scale parameter.
+We choose the default distributions for all other blob parameters. We would set up the Model as follows:
 
 .. literalinclude:: ../tests/test_docs.py
    :language: python
    :start-after: # PLACEHOLDER blob_factory_0
    :end-before: # PLACEHOLDER blob_factory_1
+
+If none of the built-in distributions fits, pass a sampling callable to ``set_sampler`` instead of a ``DistributionEnum``:
+
+.. literalinclude:: ../tests/test_docs.py
+   :language: python
+   :start-after: # PLACEHOLDER custom_sampler_0
+   :end-before: # PLACEHOLDER custom_sampler_1
 
 ++++++++++++++++++++++++++++++++++
 Pre-built blobs: Model.from_blobs

--- a/docs/changing_t_drain_plot.py
+++ b/docs/changing_t_drain_plot.py
@@ -15,27 +15,23 @@ tmp = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp),
     num_blobs=10000,
-    blob_factory=DefaultBlobFactory(
-        A_dist=DistributionEnum.deg,
-        vy_dist=DistributionEnum.zeros,
-        t_drain=t_drain,
-    ),
+    blob_factory=DefaultBlobFactory(t_drain=t_drain)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros),
 )
 
-ds_changing_t_drain = tmp.make_realization(speed_up=False)
+ds_changing_t_drain = tmp.make_realization()
 
 tmp = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp),
     num_blobs=10000,
-    blob_factory=DefaultBlobFactory(
-        A_dist=DistributionEnum.deg,
-        vy_dist=DistributionEnum.zeros,
-        t_drain=2,
-    ),
+    blob_factory=DefaultBlobFactory(t_drain=2)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros),
 )
 
-ds_constant_drain = tmp.make_realization(speed_up=False)
+ds_constant_drain = tmp.make_realization()
 
 
 def plot_cahnging_t_drain(changing, constant):

--- a/docs/create_logo.py
+++ b/docs/create_logo.py
@@ -3,7 +3,8 @@ from blobmodel import (
     Model,
     BlobFactory,
     Blob,
-    show_model,
+    BlobShapeImpl,
+    BlobShapeEnum,
     AbstractBlobShape,
 )
 import numpy as np
@@ -60,7 +61,7 @@ class CustomBlobFactory(BlobFactory):
 bf = CustomBlobFactory()
 tmp = Model(
     geometry=Geometry(Nx=64, Ny=64, Lx=10, Ly=10, dt=1, T=10, periodic_y=True),
-    blob_shape="gauss",
+    blob_shape=BlobShapeImpl(BlobShapeEnum.gaussian),
     num_blobs=3,
     blob_factory=bf,
 )

--- a/examples/1d_animation.py
+++ b/examples/1d_animation.py
@@ -10,7 +10,7 @@ from blobmodel import (
 
 # Example of a one-dimensional realization and animation.
 
-bf = DefaultBlobFactory(vy_dist=DistributionEnum.zeros, t_drain=10)
+bf = DefaultBlobFactory(t_drain=10).set_sampler("vy", DistributionEnum.zeros)
 
 bm = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=0.1, T=10, periodic_y=False),

--- a/examples/2_sided_exp_pulse.py
+++ b/examples/2_sided_exp_pulse.py
@@ -10,11 +10,8 @@ import matplotlib.pyplot as plt
 
 # Example of use of extra blob shape parameters with a double exponential blob shape.
 
-bf = DefaultBlobFactory(
-    shape_param_p_parameter=0.5,
-    shape_param_s_parameter=0.5,
-    blob_alignment=True,
-)
+# The pulse-shape asymmetry parameters ("spp"/"sps") default to 0.5.
+bf = DefaultBlobFactory(blob_alignment=True)
 
 bm = Model(
     geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=10, periodic_y=True),

--- a/examples/blob_tilting.py
+++ b/examples/blob_tilting.py
@@ -20,13 +20,15 @@ vy = 1
 wx = 3
 wy = 1
 
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg,
-    vy_parameter=vy,
-    vx_parameter=vx,
-    wp_parameter=wx,
-    ws_parameter=wy,
-    blob_alignment=True,  # Blobs will be aligned with their velocities
+bf = (
+    DefaultBlobFactory(
+        blob_alignment=True
+    )  # Blobs will be aligned with their velocities
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vx", DistributionEnum.deg, vx)
+    .set_sampler("vy", DistributionEnum.deg, vy)
+    .set_sampler("wp", DistributionEnum.deg, wx)
+    .set_sampler("ws", DistributionEnum.deg, wy)
 )
 
 
@@ -46,13 +48,13 @@ show_model(dataset=ds, interval=100, gif_name="alignment_true.gif", fps=10)
 # Now we do tilted blobs
 
 
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg,
-    vy_parameter=vy,
-    vx_parameter=vx,
-    wp_parameter=wx,
-    ws_parameter=wy,
-    blob_alignment=False,
+bf = (
+    DefaultBlobFactory(blob_alignment=False)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vx", DistributionEnum.deg, vx)
+    .set_sampler("vy", DistributionEnum.deg, vy)
+    .set_sampler("wp", DistributionEnum.deg, wx)
+    .set_sampler("ws", DistributionEnum.deg, wy)
 )
 # Blobs will NOT be aligned with their velocities, instead they will be tilted by an angle given by theta.
 

--- a/examples/changing_t_drain.py
+++ b/examples/changing_t_drain.py
@@ -18,9 +18,9 @@ decreasing_t_drain = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
     num_blobs=10000,
-    blob_factory=DefaultBlobFactory(
-        A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
-    ),
+    blob_factory=DefaultBlobFactory(t_drain=t_drain)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros),
 )
 
 ds_decreasing = decreasing_t_drain.make_realization(truncation_error=1e-2)
@@ -30,9 +30,9 @@ constant_t_drain = Model(
     geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=1, T=1000, periodic_y=False),
     blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.gaussian),
     num_blobs=10000,
-    blob_factory=DefaultBlobFactory(
-        A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=2
-    ),
+    blob_factory=DefaultBlobFactory(t_drain=2)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros),
 )
 
 ds_constant = constant_t_drain.make_realization(truncation_error=1e-2)

--- a/examples/compare_to_analytical_sol.py
+++ b/examples/compare_to_analytical_sol.py
@@ -13,8 +13,10 @@ import numpy as np
 # with analytically derived results. See O. E. Garcia, et al.; Phys. Plasmas 1 May 2016; 23 (5): 052308. https://doi.org/10.1063/1.4951016
 
 # use DefaultBlobFactory to define distribution functions fo random variables
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, vy_parameter=10
+bf = (
+    DefaultBlobFactory()
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros)
 )
 
 tmp = Model(

--- a/examples/point_process.py
+++ b/examples/point_process.py
@@ -22,9 +22,7 @@ model = bm.Model(
     geometry=bm.Geometry(Nx=1, Ny=1, Lx=1, Ly=0, dt=dt, T=T, t_init=0),
     num_blobs=num_blobs,
     blob_shape=bm.BlobShapeImpl(bm.BlobShapeEnum.exp, bm.BlobShapeEnum.gaussian),
-    blob_factory=bm.DefaultBlobFactory(
-        A_dist=bm.DistributionEnum.exp, vy_dist=bm.DistributionEnum.zeros
-    ),
+    blob_factory=bm.DefaultBlobFactory().set_sampler("vy", bm.DistributionEnum.zeros),
     verbose=True,
     one_dimensional=True,  # Checks vy = 0 and sets the y blob shape to 1.
 )

--- a/tests/test_analytical.py
+++ b/tests/test_analytical.py
@@ -12,8 +12,10 @@ import matplotlib.pyplot as plt
 
 # use DefaultBlobFactory to define distribution functions fo random variables
 t_drain = 2
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
+bf = (
+    DefaultBlobFactory(t_drain=t_drain)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros)
 )
 
 Nx, Lx = 10, 10

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -298,7 +298,7 @@ def test_get_blobs():
     """
     Tests that get_blobs() function from the model returns correct number of blobs after a realization.
     """
-    bf = DefaultBlobFactory(A_dist=DistributionEnum.deg)
+    bf = DefaultBlobFactory().set_sampler("amplitude", DistributionEnum.deg)
     model = Model(
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=1, T=1, periodic_y=False),
         num_blobs=3,
@@ -360,7 +360,9 @@ def test_no_tilt_when_theta_none_and_no_alignment():
 
 def test_theta_setter_overrides_factory_alignment():
     """A registered theta_setter wins over the factory's blob_alignment flag."""
-    bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, blob_alignment=True)
+    bf = DefaultBlobFactory(blob_alignment=True).set_sampler(
+        "amplitude", DistributionEnum.deg
+    )
     bf.set_theta_setter(lambda: 0.5)
     blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(b._theta == 0.5 for b in blobs)
@@ -368,13 +370,15 @@ def test_theta_setter_overrides_factory_alignment():
 
 def test_factory_alignment_used_without_theta_setter():
     """Without a theta_setter, the factory falls back to blob_alignment (velocity phase)."""
-    bf = DefaultBlobFactory(A_dist=DistributionEnum.deg, blob_alignment=True)
+    bf = DefaultBlobFactory(blob_alignment=True).set_sampler(
+        "amplitude", DistributionEnum.deg
+    )
     blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(np.isclose(b._theta, np.arctan2(b.v_y, b.v_x)) for b in blobs)
 
 
 def test_factory_default_is_axis_aligned():
     """With all-default arguments the factory produces untilted blobs (blob_alignment=False)."""
-    bf = DefaultBlobFactory(A_dist=DistributionEnum.deg)
+    bf = DefaultBlobFactory().set_sampler("amplitude", DistributionEnum.deg)
     blobs = bf.sample_blobs(Ly=10, T=1, num_blobs=3, blob_shape=BlobShapeImpl())
     assert all(b._theta == 0 for b in blobs)

--- a/tests/test_changing_t_drain.py
+++ b/tests/test_changing_t_drain.py
@@ -11,8 +11,10 @@ import numpy as np
 # use DefaultBlobFactory to define distribution functions fo random variables
 t_drain = np.linspace(2, 1, 10)
 
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=t_drain
+bf = (
+    DefaultBlobFactory(t_drain=t_drain)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros)
 )
 
 tmp = Model(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -49,13 +49,9 @@ def test_one_dim():
         BlobShapeEnum,
     )
 
-    bf = DefaultBlobFactory(
-        A_dist=DistributionEnum.exp,
-        wp_dist=DistributionEnum.deg,
-        vx_dist=DistributionEnum.deg,
-        vy_dist=DistributionEnum.zeros,
-        t_drain=10,
-    )
+    # Amplitudes are exponential and widths/velocities constant by default;
+    # only the y-velocity needs to be set to zero for a 1D model.
+    bf = DefaultBlobFactory(t_drain=10).set_sampler("vy", DistributionEnum.zeros)
 
     bm = Model(
         geometry=Geometry(Nx=100, Ny=1, Lx=10, Ly=0, dt=0.1, T=10, periodic_y=False),
@@ -85,13 +81,11 @@ def test_blob_shapes():
         blob_shape=BlobShapeImpl(BlobShapeEnum.exp, BlobShapeEnum.lorentz),
     )
     # PLACEHOLDER blob_shapes_1
-    bf = DefaultBlobFactory(
-        A_dist=DistributionEnum.deg,
-        wp_dist=DistributionEnum.deg,
-        spp_dist=DistributionEnum.deg,
-        sps_dist=DistributionEnum.deg,
-        shape_param_p_parameter=0.5,
-        shape_param_s_parameter=0.5,
+    bf = (
+        DefaultBlobFactory()
+        .set_sampler("amplitude", DistributionEnum.deg)
+        .set_sampler("spp", DistributionEnum.deg, 0.5)
+        .set_sampler("sps", DistributionEnum.deg, 0.5)
     )
     bm = Model(
         geometry=Geometry(Nx=100, Ny=100, Lx=10, Ly=10, dt=0.1, T=10),
@@ -110,13 +104,13 @@ def test_blob_tilt():
     vx, vy = 1, 0
     wx, wy = 1, 1
 
-    bf = DefaultBlobFactory(
-        A_dist=DistributionEnum.deg,
-        vy_parameter=vy,
-        vx_parameter=vx,
-        wp_parameter=wx,
-        ws_parameter=wy,
-        blob_alignment=False,
+    bf = (
+        DefaultBlobFactory(blob_alignment=False)
+        .set_sampler("amplitude", DistributionEnum.deg)
+        .set_sampler("vx", DistributionEnum.deg, vx)
+        .set_sampler("vy", DistributionEnum.deg, vy)
+        .set_sampler("wp", DistributionEnum.deg, wx)
+        .set_sampler("ws", DistributionEnum.deg, wy)
     )
     # PLACEHOLDER blob_tilt_1
     theta = np.pi / 2
@@ -147,8 +141,8 @@ def test_blob_factory():
     # PLACEHOLDER blob_factory_0
     from blobmodel import DefaultBlobFactory, DistributionEnum, Geometry, Model
 
-    my_blob_factory = DefaultBlobFactory(
-        A_dist=DistributionEnum.normal, A_parameter=5, t_drain=100
+    my_blob_factory = DefaultBlobFactory(t_drain=100).set_sampler(
+        "amplitude", DistributionEnum.normal, free_parameter=5
     )
 
     bm = Model(
@@ -315,3 +309,24 @@ def test_burn_in():
     )
     ds = bm.make_realization()
     # PLACEHOLDER burn_in_1
+
+
+def test_custom_sampler():
+    # PLACEHOLDER custom_sampler_0
+    from blobmodel import DefaultBlobFactory, Geometry, Model
+
+    # Draw the widths from a log-normal distribution, which is not built in.
+    # The callable receives the factory's random number generator (draw from
+    # it, not from the global np.random state, to stay seedable) and the
+    # number of blobs, and returns one value per blob.
+    bf = DefaultBlobFactory(seed=42).set_sampler(
+        "wp", lambda rng, num_blobs: rng.lognormal(sigma=0.5, size=num_blobs)
+    )
+
+    bm = Model(
+        geometry=Geometry(Nx=10, Ny=10, Lx=10, Ly=10, dt=0.1, T=20),
+        blob_factory=bf,
+        num_blobs=100,
+    )
+    ds = bm.make_realization()
+    # PLACEHOLDER custom_sampler_1

--- a/tests/test_docs_scripts.py
+++ b/tests/test_docs_scripts.py
@@ -1,0 +1,29 @@
+"""Smoke tests for the plot scripts in docs/.
+
+These scripts are not exercised by the docs build (RTD only runs Sphinx), so
+they can rot silently when the API changes — docs/create_logo.py did exactly
+that (feedback.md item 11). Running them headless catches import- and
+API-level breakage; the plots themselves are not checked.
+"""
+
+import runpy
+from pathlib import Path
+
+import matplotlib
+import pytest
+
+DOCS_DIR = Path(__file__).parent.parent / "docs"
+
+SCRIPTS = [
+    "create_logo.py",
+    "plot_pulses.py",
+    "changing_t_drain_plot.py",
+]
+
+
+@pytest.mark.parametrize("script", SCRIPTS)
+def test_docs_script_runs(script, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # saved figures land in the temp directory
+    matplotlib.use("Agg", force=True)
+    monkeypatch.setattr("matplotlib.pyplot.show", lambda *args, **kwargs: None)
+    runpy.run_path(str(DOCS_DIR / script), run_name="__main__")

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -168,8 +168,8 @@ def test_realization_rejects_wrong_length_t_drain():
     model = Model(
         geometry=Geometry(Nx=5, Ny=1, Lx=5, Ly=0, dt=1, T=2),
         num_blobs=2,
-        blob_factory=DefaultBlobFactory(
-            t_drain=np.ones(3), vy_dist=DistributionEnum.zeros
+        blob_factory=DefaultBlobFactory(t_drain=np.ones(3)).set_sampler(
+            "vy", DistributionEnum.zeros
         ),
         one_dimensional=True,
         verbose=False,

--- a/tests/test_one_dim.py
+++ b/tests/test_one_dim.py
@@ -10,8 +10,10 @@ from blobmodel import (
 import numpy as np
 
 # use DefaultBlobFactory to define distribution functions fo random variables
-bf = DefaultBlobFactory(
-    A_dist=DistributionEnum.deg, vy_dist=DistributionEnum.zeros, t_drain=2
+bf = (
+    DefaultBlobFactory(t_drain=2)
+    .set_sampler("amplitude", DistributionEnum.deg)
+    .set_sampler("vy", DistributionEnum.zeros)
 )
 
 one_dim_model = Model(

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -42,8 +42,8 @@ def _random_model(seed=None, blob_factory=None):
 
 def test_factory_same_seed_same_blobs():
     """Two factories constructed with the same seed produce identical blobs."""
-    bf_1 = DefaultBlobFactory(A_dist=DistributionEnum.exp, seed=42)
-    bf_2 = DefaultBlobFactory(A_dist=DistributionEnum.exp, seed=42)
+    bf_1 = DefaultBlobFactory(seed=42)
+    bf_2 = DefaultBlobFactory(seed=42)
     blobs_1 = _sample_default_blobs(bf_1)
     blobs_2 = _sample_default_blobs(bf_2)
     for b1, b2 in zip(blobs_1, blobs_2):
@@ -74,10 +74,10 @@ def test_factory_accepts_generator():
 @pytest.mark.parametrize("dist", list(DistributionEnum))
 def test_all_distributions_reproducible(dist):
     """The rng is threaded through every distribution sampling function."""
-    bf_1 = DefaultBlobFactory(seed=7)
-    bf_2 = DefaultBlobFactory(seed=7)
-    draws_1 = bf_1._draw_random_variables(dist, free_parameter=1, num_blobs=100)
-    draws_2 = bf_2._draw_random_variables(dist, free_parameter=1, num_blobs=100)
+    bf_1 = DefaultBlobFactory(seed=7).set_sampler("amplitude", dist)
+    bf_2 = DefaultBlobFactory(seed=7).set_sampler("amplitude", dist)
+    draws_1 = bf_1._draw_random_variables("amplitude", 100)
+    draws_2 = bf_2._draw_random_variables("amplitude", 100)
     np.testing.assert_array_equal(draws_1, draws_2)
 
 

--- a/tests/test_stochasticality.py
+++ b/tests/test_stochasticality.py
@@ -1,5 +1,6 @@
+import numpy as np
 import pytest
-from blobmodel import DefaultBlobFactory, BlobShapeImpl, BlobFactory, DistributionEnum
+from blobmodel import BlobShapeImpl, DefaultBlobFactory, DistributionEnum
 
 
 def test_mean_of_distribution():
@@ -17,28 +18,28 @@ def test_mean_of_distribution():
     distributions_mean_0 = [DistributionEnum.normal, DistributionEnum.zeros]
 
     for dist in distributions_mean_1:
-        tmp = bf._draw_random_variables(
-            dist=dist,
-            free_parameter=1,
-            num_blobs=10000,
-        )
+        bf.set_sampler("amplitude", dist)
+        tmp = bf._draw_random_variables("amplitude", 10000)
         assert 0.95 <= tmp.mean() <= 1.05
 
     for dist in distributions_mean_0:
-        tmp = bf._draw_random_variables(
-            dist=dist,
-            free_parameter=1,
-            num_blobs=10000,
-        )
+        bf.set_sampler("amplitude", dist)
+        tmp = bf._draw_random_variables("amplitude", 10000)
         assert -0.05 <= tmp.mean() <= 0.05
 
 
 def test_not_implemented_distribution():
     """
-    Checks that a TypeError is thrown when using unknown strings as distributions.
+    Checks that a TypeError is thrown when using unknown strings as samplers.
     """
-    with pytest.raises(TypeError, match="A_dist"):
-        DefaultBlobFactory(A_dist="something_different")
+    with pytest.raises(TypeError, match="amplitude"):
+        DefaultBlobFactory().set_sampler("amplitude", "something_different")
+
+
+def test_unknown_parameter_raises():
+    """set_sampler must reject parameter names it does not know."""
+    with pytest.raises(ValueError, match="Unknown parameter"):
+        DefaultBlobFactory().set_sampler("A", DistributionEnum.exp)
 
 
 def test_uniform_width_parameter_too_big_raises():
@@ -46,10 +47,10 @@ def test_uniform_width_parameter_too_big_raises():
     A uniform width distribution with free_parameter > 2 would produce negative
     widths and must be rejected.
     """
-    with pytest.raises(ValueError, match="wp_parameter"):
-        DefaultBlobFactory(wp_dist=DistributionEnum.uniform, wp_parameter=3)
-    with pytest.raises(ValueError, match="ws_parameter"):
-        DefaultBlobFactory(ws_dist=DistributionEnum.uniform, ws_parameter=2.5)
+    with pytest.raises(ValueError, match="wp"):
+        DefaultBlobFactory().set_sampler("wp", DistributionEnum.uniform, 3)
+    with pytest.raises(ValueError, match="ws"):
+        DefaultBlobFactory().set_sampler("ws", DistributionEnum.uniform, 2.5)
 
 
 def test_uniform_width_parameter_at_limit_accepted():
@@ -57,8 +58,8 @@ def test_uniform_width_parameter_at_limit_accepted():
     free_parameter = 2 (support [0, 2]) and non-uniform distributions with big
     parameters are still accepted.
     """
-    DefaultBlobFactory(wp_dist=DistributionEnum.uniform, wp_parameter=2)
-    DefaultBlobFactory(wp_dist=DistributionEnum.exp, wp_parameter=3)
+    DefaultBlobFactory().set_sampler("wp", DistributionEnum.uniform, 2)
+    DefaultBlobFactory().set_sampler("wp", DistributionEnum.exp, 3)
 
 
 def test_rayleigh_ignores_free_parameter():
@@ -68,9 +69,84 @@ def test_rayleigh_ignores_free_parameter():
     """
     bf = DefaultBlobFactory(seed=42)
     for free_parameter in [1, 100]:
-        tmp = bf._draw_random_variables(
-            dist=DistributionEnum.rayleigh,
-            free_parameter=free_parameter,
-            num_blobs=10000,
-        )
+        bf.set_sampler("amplitude", DistributionEnum.rayleigh, free_parameter)
+        tmp = bf._draw_random_variables("amplitude", 10000)
         assert 0.95 <= tmp.mean() <= 1.05
+
+
+def test_callable_sampler_used_for_blobs():
+    """A callable sampler's values must end up on the sampled blobs."""
+    bf = DefaultBlobFactory().set_sampler(
+        "amplitude", lambda rng, num_blobs: np.arange(1.0, num_blobs + 1)
+    )
+    blobs = bf.sample_blobs(Ly=10, T=10, num_blobs=3, blob_shape=BlobShapeImpl())
+    assert sorted(b.amplitude for b in blobs) == [1.0, 2.0, 3.0]
+
+
+def test_callable_sampler_receives_factory_rng():
+    """
+    The callable is given the factory's generator, so drawing from it makes
+    two same-seeded factories produce identical blobs.
+    """
+
+    def sampler(rng, num_blobs):
+        return rng.exponential(size=num_blobs)
+
+    blobs = [
+        DefaultBlobFactory(seed=42)
+        .set_sampler("amplitude", sampler)
+        .sample_blobs(Ly=10, T=10, num_blobs=5, blob_shape=BlobShapeImpl())
+        for _ in range(2)
+    ]
+    for b1, b2 in zip(*blobs):
+        assert b1.amplitude == b2.amplitude
+
+
+def test_callable_sampler_with_free_parameter_raises():
+    """free_parameter has no meaning for a callable sampler."""
+    with pytest.raises(ValueError, match="free_parameter"):
+        DefaultBlobFactory().set_sampler(
+            "amplitude", lambda rng, num_blobs: np.ones(num_blobs), 2.0
+        )
+
+
+def test_callable_sampler_wrong_shape_raises():
+    """A sampler returning the wrong number of values must be rejected."""
+    bf = DefaultBlobFactory().set_sampler(
+        "amplitude", lambda rng, num_blobs: np.ones(num_blobs + 1)
+    )
+    with pytest.raises(ValueError, match="amplitude"):
+        bf.sample_blobs(Ly=10, T=10, num_blobs=3, blob_shape=BlobShapeImpl())
+
+
+def test_default_factory_defaults():
+    """
+    A bare DefaultBlobFactory samples exponential amplitudes with mean 1 (the
+    canonical FPP choice) and constant values for everything else: widths and
+    velocities 1, shape parameters 0.5.
+    """
+    bf = DefaultBlobFactory(seed=42)
+    blobs = bf.sample_blobs(Ly=10, T=10, num_blobs=1000, blob_shape=BlobShapeImpl())
+    amps = np.array([b.amplitude for b in blobs])
+    assert 0.9 <= amps.mean() <= 1.1
+    assert amps.std() > 0
+    assert all(b.width_p == 1 and b.width_s == 1 for b in blobs)
+    assert all(b.v_x == 1 and b.v_y == 1 for b in blobs)
+
+
+def test_is_one_dimensional_only_for_zeros_enum():
+    """
+    Only the built-in zeros distribution for "vy" marks the factory as
+    one-dimensional; a callable sampler does not, even if it returns zeros.
+    """
+    assert not DefaultBlobFactory().is_one_dimensional()
+    assert (
+        DefaultBlobFactory()
+        .set_sampler("vy", DistributionEnum.zeros)
+        .is_one_dimensional()
+    )
+    assert not (
+        DefaultBlobFactory()
+        .set_sampler("vy", lambda rng, num_blobs: np.zeros(num_blobs))
+        .is_one_dimensional()
+    )


### PR DESCRIPTION
Implements the last two items (10 and 11) of the API-improvement work package.

Closes #101.

## Item 10 — `DefaultBlobFactory` configuration rework (breaking)

The fourteen `*_dist`/`*_parameter` constructor arguments are gone; the constructor keeps only `t_drain`, `blob_alignment` and `seed`. Per-parameter distributions are configured with the chainable setter:

```python
bf = (
    DefaultBlobFactory(t_drain=2)
    .set_sampler("amplitude", DistributionEnum.deg)
    .set_sampler("vx", DistributionEnum.deg, free_parameter=2.0)
    .set_sampler("wp", lambda rng, n: rng.lognormal(size=n))  # custom sampler
)
```

- Parameter keys: `"amplitude"`, `"wp"`, `"ws"`, `"vx"`, `"vy"`, `"spp"`, `"sps"`.
- `sampler` is a `DistributionEnum` **or** an arbitrary `Callable[[np.random.Generator, int], np.ndarray]` (exported as `ParameterSampler`) — the per-parameter counterpart of `CallableBlobFactory`'s whole-blob getter, per the coordination note in the survey. Callables receive the factory's rng, so they stay seedable; output length is validated.
- **Defaults unchanged**: exponential amplitude with mean 1, everything else degenerate (widths/velocities 1, shape parameters 0.5). A bare `Model()` realizes the same statistics as before.
- Validation preserved: uniform width `free_parameter > 2` rejected, unknown parameters/samplers rejected, `free_parameter` combined with a callable rejected.
- `is_one_dimensional()` recognizes only the built-in `zeros` enum for `"vy"`; callable samplers are assumed 2D (documented).
- Docs (`blob_factory.rst`) rewritten for the new API with a tested custom-sampler example; all in-repo call sites migrated.

## Item 11 — docs plot scripts

- `docs/create_logo.py` passed `blob_shape="gauss"`, a `TypeError` on `main` since the `AbstractBlobShape` requirement — fixed to `BlobShapeImpl(BlobShapeEnum.gaussian)`.
- New `tests/test_docs_scripts.py` runs all three docs plot scripts headless (Agg backend, `plt.show` stubbed, figures into tmp), so they can't rot silently again.
- `changing_t_drain_plot.py` switched from `speed_up=False` to the default truncation — profiles verified identical to machine precision, script runtime 43 s → 2 s.

## Migration notes (downstream)

Only the archived `2d_fpp` scripts and `imaging-methods/examples/synthetic_data.py` use the removed constructor arguments. Mapping: `A_dist=X, A_parameter=p` → `.set_sampler("amplitude", X, p)`, and likewise `wp/ws/vx/vy`, `spp_dist`/`shape_param_p_parameter` → `"spp"`, `sps_dist`/`shape_param_s_parameter` → `"sps"`.

With this, all items of the API-improvement work package have landed; the 2.0.0 version bump is unblocked.

All 195 tests pass; `black --check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)