### PR TITLE
Pre-2.0.0 review fixes: tilt-aware speed_up window, vy default, robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ You can specify the blob parameters with a BlobFactory class. The DefaultBlobFac
 from blobmodel import DefaultBlobFactory, DistributionEnum, Geometry, Model
 
 # use DefaultBlobFactory to define distribution functions of random variables
-my_blob_factory = DefaultBlobFactory(
-    A_dist=DistributionEnum.normal, A_parameter=5, t_drain=100
+my_blob_factory = DefaultBlobFactory(t_drain=100).set_sampler(
+    "amplitude", DistributionEnum.normal, free_parameter=5
 )
 
 # pass on my_blob_factory when creating the Model

--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -75,8 +75,10 @@ class Blob:
         t_init : float, optional
             Initial time of the blob. Default 0.
         t_drain : Union[float, NDArray], optional
-            Time scale for the blob to drain. Default ``np.inf`` = no
-            draining.
+            Time scale for the blob to drain. Either a scalar or a 1D
+            array-like of length Nx (one value per grid point in the
+            x-direction); array-likes are stored as float numpy arrays.
+            Default ``np.inf`` = no draining.
         shape_parameters_p : dict
             Additional shape parameters for the propagation direction.
         shape_parameters_s : dict
@@ -123,7 +125,14 @@ class Blob:
         self.pos_x0 = pos_x0
         self.pos_y0 = pos_y0
         self.t_init = t_init
-        self.t_drain = t_drain
+        # Normalize to float scalar or float array so downstream code can
+        # rely on np.ndim and numpy indexing (lists and numpy integer
+        # scalars would otherwise fail deep inside _drain).
+        self.t_drain: Union[float, np.ndarray] = (
+            float(t_drain)
+            if np.ndim(t_drain) == 0
+            else np.asarray(t_drain, dtype=np.float64)
+        )
         self.shape_parameters_p = (
             {} if shape_parameters_p is None else shape_parameters_p
         )
@@ -137,6 +146,13 @@ class Blob:
             self._theta = cmath.phase(self.v_x + self.v_y * 1j)
         else:
             self._theta = 0
+
+    @property
+    def theta(self) -> float:
+        """float: Tilt angle used when discretizing the blob, measured from
+        the x-axis (read-only). Resolved at construction from the explicit
+        ``theta`` argument or, when that is None, from ``blob_alignment``."""
+        return self._theta
 
     def discretize_blob(
         self,
@@ -315,9 +331,9 @@ class Blob:
             Drain factor.
 
         """
-        if isinstance(self.t_drain, (int, float)):
-            return np.exp(-(t - self.t_init) / float(self.t_drain))
-        return np.exp(-(t - self.t_init) / self.t_drain[np.newaxis, :, np.newaxis])
+        if isinstance(self.t_drain, np.ndarray):
+            return np.exp(-(t - self.t_init) / self.t_drain[np.newaxis, :, np.newaxis])
+        return np.exp(-(t - self.t_init) / self.t_drain)
 
     def _blob_trajectory_x(self, t: Union[int, NDArray]) -> Any:
         """

--- a/blobmodel/geometry.py
+++ b/blobmodel/geometry.py
@@ -123,7 +123,8 @@ class Geometry:
         Raises
         ------
         ValueError
-            If any array is not 1D, is empty, or is not uniformly spaced.
+            If any array is not 1D, is empty, is not uniformly spaced, or is
+            not strictly increasing.
         """
         x, y, t = np.asarray(x), np.asarray(y), np.asarray(t)
         for name, arr in (("x", x), ("y", y), ("t", t)):
@@ -134,6 +135,11 @@ class Geometry:
                 spacings, spacings[0], rtol=1e-8, atol=0
             ):
                 raise ValueError(f"{name} must be uniformly spaced.")
+            # A descending array passes the uniform-spacing check but yields
+            # a negative domain length, silently breaking the speed_up
+            # truncation windows.
+            if arr.size > 1 and spacings[0] <= 0:
+                raise ValueError(f"{name} must be strictly increasing.")
 
         dx = x[1] - x[0] if x.size > 1 else 1.0
         dy = y[1] - y[0] if y.size > 1 else 0.0

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -322,15 +322,16 @@ class Model:
 
         # Array-valued t_drain (drain time varying along x) must match the
         # grid; only the model knows Nx, so this cannot be checked by the
-        # factory or the blob itself.
+        # factory or the blob itself. Blob normalizes t_drain to a float
+        # scalar or a float array at construction.
         for blob in self._blobs:
             if (
-                not isinstance(blob.t_drain, (int, float))
-                and len(blob.t_drain) != self._geometry.Nx
+                isinstance(blob.t_drain, np.ndarray)
+                and blob.t_drain.size != self._geometry.Nx
             ):
                 raise ValueError(
                     f"t_drain must be a scalar or of length Nx = {self._geometry.Nx}, "
-                    f"got length {len(blob.t_drain)}."
+                    f"got length {blob.t_drain.size}."
                 )
 
         if self._geometry.periodic_y and not self._one_dimensional and self._blobs:
@@ -477,10 +478,15 @@ class Model:
             blob.v_x * dt
         )
         idx_Lx = idx_x0 + self._geometry.Lx / (blob.v_x * dt)
+        # Decay length of the blob along the x-axis: the blob-frame widths
+        # projected onto x through the tilt angle (width_p for an untilted
+        # blob, width_s at theta = pi/2).
+        width_x = (
+            np.abs(np.cos(blob.theta)) * blob.width_p
+            + np.abs(np.sin(blob.theta)) * blob.width_s
+        )
         margin = (
-            -blob.width_p
-            * np.log(truncation_error * np.sqrt(np.pi))
-            / np.abs(blob.v_x * dt)
+            -width_x * np.log(truncation_error * np.sqrt(np.pi)) / np.abs(blob.v_x * dt)
         )
         start = int(np.clip(min(idx_x0, idx_Lx) - margin, 0, self._geometry.t.size))
         stop = int(np.clip(max(idx_x0, idx_Lx) + margin, 0, self._geometry.t.size))

--- a/blobmodel/plotting.py
+++ b/blobmodel/plotting.py
@@ -41,6 +41,13 @@ def show_model(
         The animation object. Keep a reference to it as long as the animation
         should stay alive.
 
+    Raises
+    ------
+    ValueError
+        If the dataset has no `t` coordinate, e.g. because it was produced
+        with ``layout="imaging"`` (`frames`/`time`); only the default layout
+        is supported for plotting.
+
     Notes
     -----
     - This function chooses between a 1D and 2D visualizations based on the dimensionality of the dataset.
@@ -48,6 +55,14 @@ def show_model(
       over the whole dataset.
 
     """
+    if "t" not in dataset.coords:
+        raise ValueError(
+            "show_model expects a dataset in the default layout (with a `t` "
+            "coordinate); imaging-layout datasets (`frames`/`time`) are not "
+            'supported. Make the realization with layout="default" for '
+            "plotting."
+        )
+
     import matplotlib.pyplot as plt
     from matplotlib import animation
 
@@ -131,7 +146,13 @@ def _setup_1d_plot(dataset, variable):
     """
     import matplotlib.pyplot as plt
 
-    ax = plt.axes(xlim=(0, dataset.x[-1]), ylim=(0, dataset[variable].max()))
+    data = dataset[variable]
+    # x starts at the domain origin (x0 may be nonzero); the y-range must
+    # include negative values, which dipole-shaped blobs produce.
+    ax = plt.axes(
+        xlim=(float(dataset.x[0]), float(dataset.x[-1])),
+        ylim=(float(data.min()), float(data.max())),
+    )
     tx = ax.set_title(r"$t = 0$")
     (line,) = ax.plot([], [], lw=2)
     ax.set_xlabel(r"$x$")

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -169,9 +169,11 @@ class DefaultBlobFactory(BlobFactory):
 
     Samples each blob parameter independently. Every parameter defaults to a
     degenerate (constant) distribution except the amplitude, which is
-    exponential with mean 1 (the canonical FPP choice). Individual parameters
-    are reconfigured with `set_sampler`, which accepts either a
-    `DistributionEnum` or an arbitrary sampling callable.
+    exponential with mean 1 (the canonical FPP choice), and the perpendicular
+    velocity ``vy``, which is zero (matching the `Blob` default ``v_y=0``, and
+    making the default factory compatible with one-dimensional models).
+    Individual parameters are reconfigured with `set_sampler`, which accepts
+    either a `DistributionEnum` or an arbitrary sampling callable.
     """
 
     # Configurable parameter names -> (default distribution, free parameter).
@@ -180,7 +182,7 @@ class DefaultBlobFactory(BlobFactory):
         "wp": (DistributionEnum.deg, 1.0),
         "ws": (DistributionEnum.deg, 1.0),
         "vx": (DistributionEnum.deg, 1.0),
-        "vy": (DistributionEnum.deg, 1.0),
+        "vy": (DistributionEnum.zeros, 0.0),
         "spp": (DistributionEnum.deg, 0.5),
         "sps": (DistributionEnum.deg, 0.5),
     }
@@ -195,9 +197,14 @@ class DefaultBlobFactory(BlobFactory):
         Default implementation of BlobFactory.
 
         Blob parameter distributions are configured with `set_sampler`; the
-        defaults are an exponential amplitude with mean 1 and degenerate
-        (constant) distributions for everything else: widths and velocities 1,
-        shape parameters 0.5.
+        defaults are an exponential amplitude with mean 1, zero perpendicular
+        velocity ``vy``, and degenerate (constant) distributions for
+        everything else: widths and ``vx`` 1, shape parameters 0.5.
+
+        .. versionchanged:: 2.0.0
+            ``vy`` previously defaulted to the constant 1, so a bare factory
+            produced diagonally propagating blobs (inconsistent with the
+            `Blob` default ``v_y=0``) and was not one-dimensional-compatible.
 
         Parameters
         ----------

--- a/docs/blob_factory.rst
+++ b/docs/blob_factory.rst
@@ -29,7 +29,7 @@ We can use the ``DefaultBlobFactory`` class in order to change the distribution 
    * - "spp" / "sps"
      - pulse shape parameters in the principal and secondary direction
 
-By default, the amplitude is exponentially distributed with mean 1 and all other parameters are constant (widths and velocities 1, shape parameters 0.5).
+By default, the amplitude is exponentially distributed with mean 1, the perpendicular velocity ``vy`` is zero, and all other parameters are constant (widths and ``vx`` 1, shape parameters 0.5).
 Individual parameters are reconfigured with the ``set_sampler`` method, which takes the parameter name and either one of the built-in distributions or a custom sampling callable. The following distribution functions are implemented:
 
 .. list-table:: 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -358,6 +358,42 @@ def test_no_tilt_when_theta_none_and_no_alignment():
     assert blob._theta == 0
 
 
+def test_theta_property_exposes_resolved_angle():
+    """The read-only theta property returns the angle actually used for
+    discretization: the explicit theta if given, else the alignment result."""
+    assert _make_blob(theta=1.0).theta == 1.0
+    assert np.isclose(_make_blob(blob_alignment=True).theta, np.pi / 4)
+    assert _make_blob().theta == 0
+    with pytest.raises(AttributeError):
+        _make_blob().theta = 2.0
+
+
+@pytest.mark.parametrize(
+    "t_drain", [[2.0, 4.0, 8.0, 16.0], np.int64(10), np.float64(10.0)]
+)
+def test_t_drain_is_normalized(t_drain):
+    """
+    t_drain given as a plain list or a numpy scalar must work end to end:
+    Blob normalizes it to a float scalar or float array at construction
+    (lists and numpy integers used to fail deep inside the drain factor).
+    """
+    blob = Blob(t_drain=t_drain)
+    if np.ndim(t_drain) == 0:
+        assert isinstance(blob.t_drain, float)
+    else:
+        assert isinstance(blob.t_drain, np.ndarray)
+        assert blob.t_drain.dtype == np.float64
+    geometry = Geometry(
+        Nx=np.size(t_drain) if np.ndim(t_drain) else 4, Ny=2, Lx=4, Ly=2, dt=0.5, T=2
+    )
+    ds = Model.from_blobs([blob], geometry=geometry, verbose=False).make_realization()
+    reference_blob = Blob(t_drain=np.asarray(t_drain, dtype=np.float64))
+    ds_ref = Model.from_blobs(
+        [reference_blob], geometry=geometry, verbose=False
+    ).make_realization()
+    np.testing.assert_array_equal(ds.n.values, ds_ref.n.values)
+
+
 def test_theta_setter_overrides_factory_alignment():
     """A registered theta_setter wins over the factory's blob_alignment flag."""
     bf = DefaultBlobFactory(blob_alignment=True).set_sampler(

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -192,6 +192,12 @@ def test_from_arrays_rejects_bad_input():
         Geometry.from_arrays(np.zeros((2, 2)), x, t)
     with pytest.raises(ValueError, match="1D"):
         Geometry.from_arrays(x, x, np.array([]))
+    # descending arrays are uniformly spaced but would give negative domain
+    # lengths, breaking the speed_up truncation windows
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Geometry.from_arrays(x[::-1], np.array([0.0]), t)
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Geometry.from_arrays(x, x, t[::-1])
 
 
 def test_model_accepts_geometry_and_exposes_it():

--- a/tests/test_show_model.py
+++ b/tests/test_show_model.py
@@ -3,6 +3,7 @@ import sys
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt
+import pytest
 from blobmodel import Geometry, Model, show_model
 import warnings
 
@@ -86,6 +87,37 @@ def test_color_scale_is_global():
     im = fig.axes[0].images[0]
     assert im.get_clim() == (float(ds_2d.n.min()), float(ds_2d.n.max()))
     plt.close("all")
+
+
+@patch("matplotlib.pyplot.show")
+def test_1d_plot_honors_domain_origin(mock_show):
+    """
+    The 1D plot x-limits must start at the domain origin (x0 may be nonzero),
+    not at a hardcoded 0.
+    """
+    warnings.filterwarnings("ignore")
+    bm = Model(
+        geometry=Geometry(Nx=10, Ny=1, Lx=10, Ly=0, dt=0.1, T=1, x0=100.0),
+        num_blobs=1,
+        one_dimensional=True,
+    )
+    ds = bm.make_realization()
+    show_model(dataset=ds, show=False)
+    xlim = plt.gca().get_xlim()
+    assert xlim[0] == pytest.approx(float(ds.x[0]))
+    assert xlim[1] == pytest.approx(float(ds.x[-1]))
+    plt.close("all")
+
+
+def test_imaging_layout_raises_clear_error():
+    """
+    Imaging-layout datasets (frames/time, no t coordinate) are not plottable
+    with show_model; the failure must be a clear ValueError instead of an
+    AttributeError from deep inside.
+    """
+    ds_imaging = bm_2d.make_realization(layout="imaging")
+    with pytest.raises(ValueError, match="imaging"):
+        show_model(dataset=ds_imaging, variable="frames")
 
 
 def test_import_does_not_pull_matplotlib():

--- a/tests/test_speed_up.py
+++ b/tests/test_speed_up.py
@@ -237,6 +237,36 @@ def test_speed_up_realization_matches_full_on_offset_domain(x0, blob_kwargs):
     np.testing.assert_allclose(ds_fast.n.values, ds_full.n.values, atol=10 * ERROR)
 
 
+# (blob_kwargs). Tilted blobs whose extent along x is governed by width_s:
+# the truncation margin must use the widths projected through theta, not
+# width_p alone (which truncated most of the blob for these cases).
+TILTED_CONFIGS = [
+    dict(width_p=0.1, width_s=5.0, v_x=1.0, theta=np.pi / 2),  # x-extent = width_s
+    dict(width_p=0.1, width_s=5.0, v_x=1.0, theta=2.0),  # oblique tilt
+    dict(width_p=0.1, width_s=5.0, v_x=0.5, v_y=5.0, blob_alignment=True),
+]
+
+
+@pytest.mark.parametrize("blob_kwargs", TILTED_CONFIGS)
+def test_speed_up_realization_matches_full_for_tilted_blob(blob_kwargs):
+    """
+    End-to-end guard for tilted blobs (explicit theta or blob_alignment):
+    with speed_up the realization must match the untruncated one to within
+    the truncation error. The long time axis makes the window actually
+    truncate, so a margin based on width_p alone fails by O(field max).
+    """
+    geometry_kwargs = dict(Nx=32, Ny=32, Lx=10, Ly=10, dt=0.1, T=60)
+    blob = Blob(pos_y0=5.0, t_init=20.0, **blob_kwargs)
+    ds_full = Model.from_blobs(
+        [blob], geometry=Geometry(**geometry_kwargs), verbose=False
+    ).make_realization(speed_up=False)
+    ds_fast = Model.from_blobs(
+        [blob], geometry=Geometry(**geometry_kwargs), verbose=False
+    ).make_realization(truncation_error=ERROR)
+    assert ds_full.n.values.max() > 0.1  # guard: the blob really contributes
+    np.testing.assert_allclose(ds_fast.n.values, ds_full.n.values, atol=10 * ERROR)
+
+
 def test_make_realization_defaults_to_speed_up():
     """
     speed_up=True with truncation_error=1e-10 is the documented default

--- a/tests/test_stochasticality.py
+++ b/tests/test_stochasticality.py
@@ -122,8 +122,9 @@ def test_callable_sampler_wrong_shape_raises():
 def test_default_factory_defaults():
     """
     A bare DefaultBlobFactory samples exponential amplitudes with mean 1 (the
-    canonical FPP choice) and constant values for everything else: widths and
-    velocities 1, shape parameters 0.5.
+    canonical FPP choice), zero perpendicular velocity (matching the Blob
+    default v_y=0) and constant values for everything else: widths and vx 1,
+    shape parameters 0.5.
     """
     bf = DefaultBlobFactory(seed=42)
     blobs = bf.sample_blobs(Ly=10, T=10, num_blobs=1000, blob_shape=BlobShapeImpl())
@@ -131,18 +132,19 @@ def test_default_factory_defaults():
     assert 0.9 <= amps.mean() <= 1.1
     assert amps.std() > 0
     assert all(b.width_p == 1 and b.width_s == 1 for b in blobs)
-    assert all(b.v_x == 1 and b.v_y == 1 for b in blobs)
+    assert all(b.v_x == 1 and b.v_y == 0 for b in blobs)
 
 
 def test_is_one_dimensional_only_for_zeros_enum():
     """
     Only the built-in zeros distribution for "vy" marks the factory as
-    one-dimensional; a callable sampler does not, even if it returns zeros.
+    one-dimensional (the default since vy defaults to zeros); a callable
+    sampler does not, even if it returns zeros.
     """
-    assert not DefaultBlobFactory().is_one_dimensional()
-    assert (
+    assert DefaultBlobFactory().is_one_dimensional()
+    assert not (
         DefaultBlobFactory()
-        .set_sampler("vy", DistributionEnum.zeros)
+        .set_sampler("vy", DistributionEnum.deg)
         .is_one_dimensional()
     )
     assert not (


### PR DESCRIPTION
Fixes from a final review pass over the codebase before the 2.0.0 version bump.

## Bug fix: speed_up truncation ignored blob tilt

`Model._compute_start_stop` derived the truncation margin from `width_p` alone. For tilted blobs (explicit `theta`, or `blob_alignment=True` with large `v_y`) the blob's extent along x is governed by the widths projected through the tilt angle — at `theta = pi/2` entirely by `width_s`. With a long time axis the window truncated most of such a blob (errors of order the field maximum: 0.25 against a field max of 0.32 in the reproduction), and since #157 `speed_up=True` is the default, silently. The margin now uses `|cos θ|·width_p + |sin θ|·width_s`, which reduces to `width_p` for untilted blobs; `Blob` gains a read-only `theta` property exposing the resolved angle. Covered by new end-to-end property tests (`test_speed_up_realization_matches_full_for_tilted_blob`).

## Behavior change: `DefaultBlobFactory` "vy" defaults to zeros

Previously `deg(1.0)`, so a bare factory produced diagonally propagating blobs — inconsistent with the `Blob` default `v_y=0` — and `Model(one_dimensional=True)` with a default factory always warned. Now the default factory is 1D-compatible and matches the `Blob` defaults. Done now because the 2.0.0 breaking window is open; documented with a `versionchanged` note.

## Robustness / polish

- `Blob` normalizes `t_drain` to a float scalar or float numpy array: plain lists and numpy integer scalars used to fail with opaque `TypeError`s deep inside `_drain` / the Nx length check.
- `Geometry.from_arrays` rejects non-increasing coordinate arrays (descending arrays passed the uniform-spacing check and yielded negative `Lx`, breaking the speed_up windows).
- `show_model`: 1D plot x-limits honor the domain origin (`x0` offsets, previously hardcoded to start at 0); y-limits include negative values (dipole shapes); imaging-layout datasets (`frames`/`time`) now raise a clear `ValueError` instead of an `AttributeError`.
- README: `DefaultBlobFactory` usage example migrated to the `set_sampler` API (it still used the constructor arguments removed in #158 and would raise on 2.0.0).
- `docs/blob_factory.rst` defaults sentence updated for the new `vy` default.

Test suite: 204 passed; black and mypy clean. With this, the 2.0.0 bump should be unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)