### PR TITLE
Pre-2.0.0 polish: input-validation guards and docstring fixes

### DIFF
--- a/blobmodel/blobs.py
+++ b/blobmodel/blobs.py
@@ -13,7 +13,7 @@ class Blob:
     the function `discretize_blob`. The contribution of a single blob to a grid defined by `x`, `y` and `t` is given by:
 
     .. math::
-        a e^{-(t-t_k)/\\tau_\\shortparallel}\\varphi\\left( \\frac{x-v(t-t_k)}{\ell_x}, \\frac{(y-y_k)-w(t-t_k)}{\ell_y} \\right)
+        a e^{-(t-t_k)/\\tau_\\shortparallel}\\varphi\\left( \\frac{(x-x_k)-v(t-t_k)}{\ell_x}, \\frac{(y-y_k)-w(t-t_k)}{\ell_y} \\right)
 
     Where:
         - :math:`a` is the blob amplitude, `amplitude`.
@@ -21,11 +21,16 @@ class Blob:
         - :math:`\ell_y` is the blob width in the secondary direction, `width_s`.
         - :math:`v` is the horizontal blob velocity.
         - :math:`w` is the vertical blob velocity.
-        - :math:`t_k` is the blob arriving time at the position x=0, `t_init`.
+        - :math:`x_k` and :math:`y_k` are the blob position at time :math:`t_k`,
+          `pos_x0` and `pos_y0`.
+        - :math:`t_k` is the time at which the blob is seeded at
+          :math:`(x_k, y_k)`, `t_init`.
         - :math:`\\tau_\\shortparallel` is the drainage time, `t_drain`.
         - :math:`\\varphi` is the blob pulse shape, `blob_shape`.
 
-    Additionally, a tilt angle can be provided through `theta`.
+    Additionally, a tilt angle can be provided through `theta`, in which case
+    the two arguments of :math:`\\varphi` are rotated by `theta` around the
+    blob center.
     """
 
     def __init__(

--- a/blobmodel/geometry.py
+++ b/blobmodel/geometry.py
@@ -61,7 +61,18 @@ class Geometry:
             Origin of the domain in the y-direction, analogous to ``x0``. Note
             that `DefaultBlobFactory` samples blob positions ``pos_y0`` in
             ``[0, Ly]`` regardless of ``y0``.
+
+        Raises
+        ------
+        ValueError
+            If ``periodic_y`` is True and ``Ly`` is 0: y-periodicity is
+            meaningless in a zero-width domain, and wrapping blob positions
+            would divide by ``Ly``.
         """
+        if periodic_y and Ly == 0:
+            raise ValueError(
+                "periodic_y=True requires a domain with Ly > 0, got Ly = 0."
+            )
         self.Nx = Nx
         self.Ny = Ny
         self.Lx = Lx

--- a/blobmodel/model.py
+++ b/blobmodel/model.py
@@ -94,8 +94,9 @@ class Model:
             AbstractBlobShape instance or blob_factory is not a BlobFactory
             instance.
         ValueError
-            If the model is one-dimensional and the geometry does not have
-            Ny=1 and Ly=0.
+            If ``labels`` is not one of the values listed above, or if the
+            model is one-dimensional and the geometry does not have Ny=1 and
+            Ly=0.
 
         Warns
         -----
@@ -119,6 +120,10 @@ class Model:
         if not isinstance(blob_factory, BlobFactory):
             raise TypeError(
                 f"blob_factory must be a BlobFactory, got {type(blob_factory).__name__}."
+            )
+        if labels not in {"off", "same", "individual"}:
+            raise ValueError(
+                f'labels must be "off", "same" or "individual", got labels = "{labels}".'
             )
         if seed is not None:
             blob_factory.set_rng(np.random.default_rng(seed))

--- a/blobmodel/stochasticality.py
+++ b/blobmodel/stochasticality.py
@@ -62,7 +62,7 @@ class BlobListFactory(BlobFactory):
 
     Use this (typically through `Model.from_blobs`) when the blobs are
     constructed by hand instead of sampled from distributions. All
-    `sample_blobs` arguments (`num_blobs`, `blob_shape`, `t_drain`, ...) are
+    `sample_blobs` arguments (`Ly`, `T`, `num_blobs`, `blob_shape`) are
     ignored: each `Blob` already carries its own parameters.
     """
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -149,6 +149,26 @@ def test_model_rejects_wrong_types():
         Model(blob_factory="default")
 
 
+def test_model_rejects_unknown_labels():
+    """
+    Model raises ValueError for a labels value that is not "off", "same" or
+    "individual"; previously a typo was silently treated as "off".
+    """
+    for bad_labels in ["individal", "Individual", ""]:
+        with pytest.raises(ValueError, match="labels"):
+            Model(labels=bad_labels)
+
+
+def test_geometry_rejects_periodic_y_with_zero_ly():
+    """
+    Geometry raises ValueError for periodic_y=True with Ly=0; previously the
+    combination silently produced an all-NaN density field (floor division by
+    Ly = 0 when wrapping blob positions).
+    """
+    with pytest.raises(ValueError, match="periodic_y"):
+        Geometry(Ly=0, periodic_y=True)
+
+
 def test_factory_rejects_nonpositive_t_drain():
     """
     DefaultBlobFactory raises ValueError for non-positive t_drain values


### PR DESCRIPTION
Final source review before the 2.0.0 version bump. Two small validation guards and two docstring-drift fixes; no behavior change for valid inputs.

## Bug fixes

- **`Geometry` rejects `periodic_y=True` with `Ly=0`.** This combination previously ran to completion and returned an all-NaN density field, caused by the floor division `(vertical_prop - y0) // Ly` in `Blob.discretize_blob` when wrapping blob positions. It now raises `ValueError` at construction.
- **`Model` validates `labels`.** Any value other than `"off"`, `"same"` or `"individual"` (e.g. a typo like `"individal"`) was silently treated as `"off"`, returning a dataset without `blob_labels` and no hint why. It now raises `ValueError`.

## Docstring fixes

- `BlobListFactory` no longer lists `t_drain` among the ignored `sample_blobs` arguments — it was removed from that signature in #153.
- The `Blob` class-level pulse formula now includes the seeding position `x_k` (it read `x - v(t - t_k)`, which is only correct for `pos_x0 = 0`), defines `x_k`/`y_k`, describes `t_init` as the seeding time at `(x_k, y_k)` instead of "the arriving time at x=0", and notes that `theta` rotates the pulse-shape arguments.

## Tests

Two new tests in `tests/test_input_validation.py` covering the new guards. Full suite: 206 passed; `black --check` and `mypy --ignore-missing-imports blobmodel` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)